### PR TITLE
Docs: Clarify Readme and Add Contributing Guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,62 @@
+# Contributing to ZecHub Wiki
+
+> ZecHub helps people learn about Zcash
+
+If you're reading this page, we're really excited that you're considering contributing! Any contribution you make will be reflected on [zechub.wiki](https://zechub.wiki/) :sparkles:
+
+<!-- TODO: We need to have a CoC -->
+<!-- Read our [Code of Conduct](/CODE_OF_CONDUCT.md) to keep our community approachable and respectable. -->
+
+## New contributors
+
+To get an overview of ZecHub Wiki, read the [README](/README.md).
+
+## Join the conversation
+
+First, join the conversation in the [Zcash Global discord](https://discord.gg/zcash). There's a ZecHub section where we chat about all things ZecHub :smile:
+
+<small> Don’t forget to add the ZecHub role in <a href="https://discord.com/channels/978714252934258779/983468150861484093">#lang-menu channel</a>! </small>
+
+## Bounty
+
+If you're familiar with Next.js, we offer paid bounty for ZecHub Wiki through dework. Go to [dework.zechub.org](https://dework.zechub.org/) to find and apply for active bounties.
+
+## Issues
+
+### Create a new issue
+
+If you spot a problem with ZecHub Wiki app, [search if an issue already exists](https://github.com/zechub/zechub-wiki/issues). If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/zechub/zechub-wiki/issues/new/choose).
+
+### Solve an issue
+
+Scan through our [existing issues](https://github.com/zechub/zechub-wiki/issues) to find one that interests you. You can narrow down the search using `labels` as filters. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
+
+## Make Changes
+
+1. Fork the repository.
+
+- Using GitHub Desktop:
+
+  - [Getting started with GitHub Desktop](https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop) will guide you through setting up Desktop.
+  - Once Desktop is set up, you can use it to [fork the repo](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/cloning-and-forking-repositories-from-github-desktop)!
+
+- Using the command line:
+  - [Fork the repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository) so that you can make your changes without affecting the original project until you're ready to merge them.
+
+2. Create a working branch and start with your changes!
+
+### Commit your update
+
+We recommend following [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) for commit title and messages. Commit the changes once you are happy with them.
+
+Don't forget to self-review to speed up the review process :zap:
+
+## Pull Request
+
+When you're finished with the changes, [create a pull request](https://github.com/zechub/zechub-wiki/pulls), also known as a PR. You can include your unified address (UA) in the PR so we can send you a tip!
+
+### To Finish
+
+Please do not hesitate to get started contributing to one of the industry's most respected protocols. This is a great way to get involved with Zcash. If you have any questions about contributing, please let us know on [Discord](#join-the-conversation).
+
+Thanks!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,45 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+<div style="text-align: center;">
+    <img src="https://i.ibb.co/Gv7Jd8Q/Zec-Hub-blue-globe.png" alt="Logo" style="width: 70px; height: auto;">
+    <h3>
+        <em>
+            An open-source education hub for <a href="https://z.cash/" target="_blank">Zcash</a>
+        </em>
+    </h3>
+    <p>
+        <a href="https://follow.zechub.org/" target="_blank">
+            <img src="https://img.shields.io/twitter/follow/zechub?style=social&label=Follow">
+        </a>
+    </p>
+<p>
+    <a href="https://chat.zechub.org/" target="_blank">
+        <img src="https://img.shields.io/discord/978714252934258779?style=social&label=Discord">
+    </a>
+    <a href="https://youtube.com/@zechub" target="_blank">
+        <img src="https://img.shields.io/youtube/channel/views/UC3-KM00kjCUheRzO5cq3PAA?style=social&label=Subscribe">
+    </a>
+</p>
+
+</div>
+
+# ZecHub Wiki
+
+Welcome to ZecHub, an open-source education hub for Zcash! This Next.js project is designed to provide a platform for educational content related to Zcash and privacy. If you're new to ZecHub or Next.js, this guide will help you get started.
 
 ## Getting Started
 
-First, run the development server:
+To set up the development environment, follow these steps:
+
+1. Install the project dependencies:
+
+```bash
+npm install
+# or
+yarn install
+# or
+pnpm install
+```
+
+2. Run the development server:
 
 ```bash
 npm run dev
@@ -12,23 +49,14 @@ yarn dev
 pnpm dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
-
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the ZecHub Wiki in action. You can start editing the page by modifying the files within the `src/app` directory. The page will auto-update as you make changes.
 
 ## Learn More
 
-To learn more about Next.js, take a look at the following resources:
+Check out [nextjs.org](http://nextjs.org) to learn more about Next.js.
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+To deepen your understanding of ZecHub, visit the deployed app at [zechub.wiki](http://zechub.wiki).
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
+## Contribute
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+ZecHub wiki is open-source and welcomes your contribution. Read our **[contributing guide](/CONTRIBUTING.md)** for more details on how.


### PR DESCRIPTION
Clarify the dev environment setup in Readme and add Contributing Guide that follows closely to zechub/zechub main repo.