### PR TITLE
Theming

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -40,7 +40,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
             </div>
 
             <div className='flex justify-center md:justify-end'>
-                <Link href="/explore" className='inline-flex rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
+                <Link href="/explore" className='flex items-center rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
                     Explore more 
                     <Icon size={'medium'} icon={Arrow} />
                 </Link>

--- a/src/app/desktop-wallets/page.tsx
+++ b/src/app/desktop-wallets/page.tsx
@@ -41,7 +41,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
             </div>
 
             <div className='flex justify-center md:justify-end'>
-                <Link href="/explore" className='inline-flex rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
+                <Link href="/explore" className='flex items-center rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
                     Explore more 
                     <Icon size={'medium'} icon={Arrow} />
                 </Link>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  background: #fff9f9;
+}
+
 .mobile-trigger{
   margin: 0!important;
 }

--- a/src/app/hardware-wallets/page.tsx
+++ b/src/app/hardware-wallets/page.tsx
@@ -41,7 +41,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
             </div>
 
             <div className='flex justify-center md:justify-end'>
-                <Link href="/explore" className='inline-flex rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
+                <Link href="/explore" className='flex items-center rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
                     Explore more 
                     <Icon size={'medium'} icon={Arrow} />
                 </Link>

--- a/src/app/mobile-wallets/page.tsx
+++ b/src/app/mobile-wallets/page.tsx
@@ -41,7 +41,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
             </div>
 
             <div className='flex justify-center md:justify-end'>
-                <Link href="/explore" className='inline-flex rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
+                <Link href="/explore" className='flex items-center rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
                     Explore more 
                     <Icon size={'medium'} icon={Arrow} />
                 </Link>

--- a/src/app/web-wallets/page.tsx
+++ b/src/app/web-wallets/page.tsx
@@ -41,7 +41,7 @@ export default async function Page({ params }: { params: { slug: string } }) {
             </div>
 
             <div className='flex justify-center md:justify-end'>
-                <Link href="/explore" className='inline-flex rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
+                <Link href="/explore" className='flex items-center rounded-full border-4  font-bold p-4 hover:bg-[#1984c7]' >
                     Explore more 
                     <Icon size={'medium'} icon={Arrow} />
                 </Link>

--- a/src/components/ContentSections.tsx
+++ b/src/components/ContentSections.tsx
@@ -15,9 +15,9 @@ const ContentSections = () => {
                         </FadeInAnimation>
                     </div>
 
-                    <div className="flex flex-col w-auto md:w-2/4 items-center justify-center font-bold">
+                    <div className="flex flex-col w-auto md:w-2/4 items-center justify-center">
                         <FadeInAnimation>
-                            <h1 className="text-3xl text-center mb-4 w-full">What is Zcash?</h1>
+                            <h1 className="text-3xl text-center mb-4 w-full font-semibold">What is Zcash?</h1>
                         </FadeInAnimation>
                         <FadeInAnimation>
                             <p className="text-center w-full mb-5">
@@ -25,10 +25,11 @@ const ContentSections = () => {
                             </p>
                         </FadeInAnimation>
                         <FadeInAnimation className="w-full">
-                            <div className="flex flex-col md:flex-row space-y-4 space-x-4 mt-4 w-full">
-                                <Link href={'/start-here/what-is-zec-and-zcash'} className="inline-flex justify-center items-center w-full px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+                            <div className="flex flex-col md:flex-row mt-4 w-full">
+                                <Link href={'/start-here/what-is-zec-and-zcash'} className="inline-flex justify-center items-center w-full px-3 py-2 text-sm font-bold text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
                                     What is Zcash?
                                 </Link>
+                                &nbsp;
                                 <Link href={'/zcash-tech/zk-snarks'} className="inline-flex justify-center items-center w-full px-3 py-2 text-sm font-medium text-center text-blue-400 border-blue-300 border-2 rounded-lg hover:bg-blue-800 hover:text-white focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
                                     Zcash Technology
                                 </Link>
@@ -38,9 +39,9 @@ const ContentSections = () => {
                 </div>
                 <div className="flex flex-col md:flex-row space-y-4 h-screen my-4 w-auto border-2 border-black/50 rounded-md p-5" style={{ height: "30rem" }}>
 
-                    <div className="flex flex-col w-auto md:w-2/4  items-center justify-center font-bold">
+                    <div className="flex flex-col w-auto md:w-2/4  items-center justify-center">
                         <FadeInAnimation>
-                            <h1 className="text-3xl mb-4">ZECPages</h1>
+                            <h1 className="text-3xl mb-4 font-semibold">ZECPages</h1>
                         </FadeInAnimation>
                         <FadeInAnimation>
                             <p className="text-center mb-5">
@@ -49,7 +50,7 @@ const ContentSections = () => {
                         </FadeInAnimation>
                         <FadeInAnimation>
                             <div className="flex flex-row space-x-4 mt-4">
-                                <Link href={'https://zecpages.com'} className="inline-flex justify-center items-center w-full px-3 py-2 text-sm font-medium text-center  border-blue-300 border-2 rounded-lg hover:bg-blue-800 hover:text-white focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
+                                <Link href={'https://zecpages.com'} className="inline-flex justify-center items-center w-full px-3 py-2 text-sm font-semibold text-center  border-blue-300 border-2 rounded-lg hover:bg-blue-800 hover:text-white focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
                                     ZECPages
                                 </Link>
                             </div>
@@ -67,12 +68,12 @@ const ContentSections = () => {
                             <Image src={'/Free2z_Banner.gif'} alt="" width={500} height={50} />
                         </FadeInAnimation>
                      </div>
-                    <div className="flex flex-col w-auto md:w-2/4 items-center justify-center font-bold">
+                    <div className="flex flex-col w-auto md:w-2/4 items-center justify-center">
                         <FadeInAnimation>
-                            <h1 className="text-3xl mb-4">Free2Z</h1>
+                            <h1 className="text-3xl mb-4 font-semibold">Free2Z</h1>
                         </FadeInAnimation>
                         <FadeInAnimation>
-                            <p className="text-center font-bold mb-5">
+                            <p className="text-center mb-5">
                               Free2Z is a social platform powered by Zcash. With peer-to-peer donations, a revenue sharing program, advanced creative tools and a massive online global community.
                             </p>
                         </FadeInAnimation>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -5,7 +5,7 @@ import SocialIcons from "./ui/SocialIcons";
 const Footer = () => {
   return (
 
-    <div className=" w-full border-t-4 border-slate-500 dark:border-slate-100 mt-3 md:py-5">
+    <div className=" w-full border-slate-500 dark:border-slate-100 mt-3 md:py-5">
       <footer className="rounded-lg shadow bg-[#1984c7] md:flex md:items-center md:flex-col py-3 text-white">
         <div className="flex justify-center items-center">
           <Logo />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -141,16 +141,16 @@ const Navigation = () => {
         <div className={"flex items-center ms-auto"}>
           <div className="flex w-auto md:p-5 md:justify-end space-x-5">
             <Icon
-              icon={dark ? LightIcon : DarkIcon}
-              className="hover:cursor-pointer h-5 w-5"
-              onClick={() => setDark(!dark)}
-            />
-            <Icon
               icon={SearchIcon}
               className="hover:cursor-pointer h-5 w-5"
               onClick={() => setOpenSearch(true)}
             />
             <SearchBar openSearch={openSearch} setOpenSearch={setOpenSearch} />
+            <Icon
+              icon={dark ? LightIcon : DarkIcon}
+              className="hover:cursor-pointer h-5 w-5"
+              onClick={() => setDark(!dark)}
+            />
           </div>
           <div
             className="hidden md:flex p-2 w-auto justify-end sm:gap-6"

--- a/src/components/home/Home.tsx
+++ b/src/components/home/Home.tsx
@@ -37,7 +37,7 @@ const Home = ({ text }: HomeProps) => {
                 </FadeInAnimation>
                 <div className="flex items-center justify-center p-4 ">
                   <FadeInAnimation>
-                    <p className="text-lg font-bold text-center">{text}</p>
+                    <p className="text-lg text-center">{text}</p>
                   </FadeInAnimation>
                 </div>
                 <div className="flex justify-center mx-auto">
@@ -45,7 +45,7 @@ const Home = ({ text }: HomeProps) => {
                     <Link
                       type="button"
                       href={"/explore"}
-                      className=" md:hover:scale-110 border-[#1984c7] transition duration-400  border-4 font-bold rounded-full  py-4 px-8"
+                      className=" md:hover:scale-110 border-[#1984c7] transition duration-400  border-4 font-bold rounded-full  py-4 px-8 color-[#1984c7]"
                     >
                       Explore Zcash
                     </Link>

--- a/src/components/ui/Cards.tsx
+++ b/src/components/ui/Cards.tsx
@@ -10,16 +10,17 @@ interface props {
 }
 
 const Cards = ({ title, paraph, url, image }: props) => (
-    <div className="max-w-sm md:w-1/5 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700 hover:-translate-y-6">
+    <div className="flex max-w-sm md:w-1/5 bg-white border border-gray-200 rounded-lg shadow dark:bg-gray-800 dark:border-gray-700 hover:-translate-y-6 transition-all duration-100">
         <FadeInAnimation>
             <Link href={url}>
                 <Image className="rounded-t-lg " src={image} alt="" width={400} height={100} />
             </Link>
-            <div className="p-5">
+            <div className="flex flex-col p-5 min-h-56">
                 <Link href={url}>
                     <h5 className="mb-2 text-2xl font-bold tracking-tight text-gray-900 dark:text-white">{title}</h5>
                 </Link>
                 <p className="mb-3 font-normal text-gray-700 dark:text-gray-400">{paraph}</p>
+                <div className="grow"></div>
                 <Link href={url} className="inline-flex justify-center items-center w-full px-3 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800">
                     Read more
                     <svg className="w-3.5 h-3.5 ml-2" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 10">

--- a/src/components/ui/DonationBtn.tsx
+++ b/src/components/ui/DonationBtn.tsx
@@ -6,7 +6,7 @@ const DonationBtn = () => {
     
   return (
     <div className='nav-donate-btn'>
-        <Link href="/donation"  className={"px-4 py-2 text-sm md:text-lg"} style={{ background:"#1984c7",  fontWeight: "600", borderRadius: "0.4rem"}}>Donate</Link>
+        <Link href="/donation"  className={"px-4 py-2 text-sm md:text-lg"} style={{ background:"#1984c7",  fontWeight: "600", borderRadius: "0.4rem", color: 'white'}}>Donate</Link>
     </div>
   )
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,9 @@ const config: Config = {
         'gradient-conic':
           'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
       },
+      colors: {
+        'white': '#fff9f9',
+      },
     },
   },
   plugins: [require('flowbite/plugin')],


### PR DESCRIPTION
**Some theming tweaks**
- Removes bottom line in footer that looked awkward
- Improves color contrast ratio on buttons. Blue text should have white color
- More consistent button usage across pages
- Better white color needed: changed default tailwind theme to slightly off white
- Bug fix: Button icon sizing is off needed centering
- Better font weight usage, i.e. normal text should be medium, only headers in bold. This is done for main page

![image](https://github.com/ZecHub/zechub-wiki/assets/16677991/c3c27387-eec0-4d8a-ab7e-7081d4b398ee)

![image](https://github.com/ZecHub/zechub-wiki/assets/16677991/c1986288-8f2e-4602-831c-8181bdcf26f9)

![image](https://github.com/ZecHub/zechub-wiki/assets/16677991/ea74f990-2fff-41dd-b995-5016e0f7b50a)

![image](https://github.com/ZecHub/zechub-wiki/assets/16677991/d301da6c-c4e7-46ca-ab05-a8cfd39ea02a)

![image](https://github.com/ZecHub/zechub-wiki/assets/16677991/07487cfe-5f57-4029-affc-3dca1fabbabb)
