### PR TITLE
fix: update banner image url

### DIFF
--- a/src/constants/contentBanners.ts
+++ b/src/constants/contentBanners.ts
@@ -77,6 +77,6 @@ export const contentBanners = [
   },
   {
     name: "contribute_Dark",
-    url: "/content-banners/contribute_Dark.jpg",
+    url: "/content-banners/Contribute_Dark.jpg",
   },
 ];


### PR DESCRIPTION
This PR contains fix of the banner image url for `contribute/help-build-zechub` page.