### PR TITLE
Add RocketX and peer to decentralized exchanges list

### DIFF
--- a/src/constants/decentralizedExchanges.ts
+++ b/src/constants/decentralizedExchanges.ts
@@ -47,6 +47,18 @@ export const decentralizedExchanges = [
     url: "https://app.routerprotocol.com/",
     image: "/routerProtocolLogo.png",
   },
+  {
+    title: "RocketX",
+    description:
+      "Hybrid CEX and DEX aggregator supporting 180+ networks. Swap any token to any chain at the best price with ultra-fast execution.",
+    url: "https://rocketx.exchange",
+    image: "/rocketx-logo.png",
+  },
+  {
+    title: "peer",
+    description:
+      "Peer-to-peer crypto exchange. Buy and sell instantly with the best rates. No middlemen, no barriers — fast, fair, and private P2P transactions.",
+    url: "https://www.peer.xyz/",
+    image: "/peer-logo.png",
+  },
 ];
-
-


### PR DESCRIPTION
## Summary

Adds two new decentralized exchanges to the wiki:

### RocketX
- Hybrid CEX/DEX aggregator
- Supports 180+ networks
- URL: https://rocketx.exchange
- RVF token (CoinGecko listed)

### peer
- Peer-to-peer crypto exchange
- No middlemen, no barriers
- URL: https://www.peer.xyz/
- Instant buy/sell with best rates

## Notes
- Both entries follow the existing format in `src/constants/decentralizedExchanges.ts`
- Logo images referenced as `/rocketx-logo.png` and `/peer-logo.png` — please add the actual image files to `public/` or update paths to valid image URLs
- Related to issue #1554

Closes #1554