### PR TITLE
feat: add peer and RocketX to DEX list

### DIFF
--- a/src/constants/decentralizedExchanges.ts
+++ b/src/constants/decentralizedExchanges.ts
@@ -47,6 +47,19 @@ export const decentralizedExchanges = [
     url: "https://app.routerprotocol.com/",
     image: "/routerProtocolLogo.png",
   },
+  {
+    title: "peer",
+    description:
+      "Privacy-first DEX with shielded trading. Swap Zcash and other assets without revealing transaction details.",
+    url: "https://peer.zec hub.org/",
+    image: "/peer.png",
+  },
+  {
+    title: "RocketX",
+    description:
+      "Cross-chain swap platform supporting 50+ blockchains. Trade between Bitcoin, Ethereum, Zcash, and other major assets with competitive rates.",
+    url: "https://rocketx.exchange/",
+    image: "/rocketx.png",
+  },
 ];
-
 


### PR DESCRIPTION
## Summary

Adds two new decentralized exchanges to the wiki:

- **peer** — Privacy-first DEX with shielded trading for Zcash
- **RocketX** — Cross-chain swap platform supporting 50+ blockchains

Both entries follow the existing format in `src/constants/decentralizedExchanges.ts`.

Closes #1554

---
Bounty: 0.1 ZEC