### PR TITLE
Add Italian language support

### DIFF
--- a/dictionaries/it.json
+++ b/dictionaries/it.json
@@ -1,0 +1,124 @@
+{
+  "common": {
+    "home": "Home",
+    "about": "Informazioni",
+    "contact": "Contatti",
+    "language": "Lingua",
+    "clickToExplore": "Clicca per esplorare →",
+    "learnMore": "Scopri di più",
+    "getStarted": "Inizia",
+    "readMore": "Leggi di più",
+    "search": "Cerca",
+    "close": "Chiudi",
+    "searchModalTitle": "Cerca in ZecHub Wiki",
+    "searchHint": "Cerca per titolo, argomento o percorso. Usa le frecce per scegliere, Invio per aprire.",
+    "searchNoResults": "Nessuna pagina trovata",
+    "searchTryDifferent": "Prova query più brevi, sinonimi o parole diverse.",
+    "searchSuggested": "Pagine suggerite",
+    "searchResultsLabel": "Risultati"
+  },
+  "navigation": {
+    "wallets": "Wallet",
+    "guides": "Guide",
+    "tutorials": "Tutorial",
+    "governance": "Governance",
+    "visualizer": "Visualizer",
+    "dao": "DAO",
+    "newsletter": "Newsletter",
+    "donate": "Dona",
+    "explore": "Esplora",
+    "developers": "Sviluppatori",
+    "community": "Community",
+    "contribute": "Contribuisci",
+    "dashboard": "Dashboard",
+    "more": "Altro",
+    "usingZcash": {
+      "label": "Usare Zcash",
+      "buyingZec": "Comprare ZEC",
+      "faucets": "Faucet",
+      "wallets": "Wallet",
+      "metamaskSnap": "Metamask Snap",
+      "exchanges": "Exchange",
+      "blockExplorers": "Block explorer",
+      "shieldedPools": "Shielded pool",
+      "transparentExchangeAddresses": "Indirizzi trasparenti degli exchange",
+      "transactions": "Transazioni",
+      "memos": "Memo",
+      "mobileTopUps": "Ricariche mobile",
+      "paymentRequestUris": "URI di richiesta pagamento",
+      "paymentProcessors": "Payment processor",
+      "recoveringFunds": "Recuperare fondi"
+    },
+    "zcashCommunity": {
+      "label": "Ecosistema",
+      "arboristCalls": "Arborist Calls",
+      "communityBlogs": "Blog della community",
+      "communityLinks": "Link della community",
+      "communityForum": "Forum della community",
+      "communityProjects": "Progetti della community",
+      "globalAmbassadors": "Zcash Global Ambassadors",
+      "zcashMedia": "Zcash Media",
+      "zcap": "ZCAP",
+      "zcashPodcasts": "Podcast Zcash",
+      "ecosystemSecurity": "Sicurezza dell'ecosistema Zcash",
+      "cypherpunkZeroNFT": "Cypherpunk Zero NFT",
+      "zconArchive": "Archivio Zcon"
+    },
+    "organizations": {
+      "label": "Organizzazioni",
+      "electricCoinCompany": "Electric Coin Company",
+      "zcashFoundation": "Zcash Foundation",
+      "communityGrants": "Zcash Community Grants",
+      "financialPrivacyFoundation": "Financial Privacy Foundation",
+      "shieldedLabs": "Shielded Labs",
+      "zingoLabs": "Zingo Labs",
+      "brand": "Brand",
+      "zkavClub": "ZKAV Club"
+    }
+  },
+  "home": {
+    "heroTitle": "Benvenuto su ZecHub",
+    "heroSubtitle": "Un hub educativo open source per Zcash",
+    "heroDescription": "Scopri la tecnologia di privacy di Zcash, esplora visualizer interattivi e contribuisci all'ecosistema",
+    "description": "ZecHub è l'hub educativo guidato dalla community per la criptovaluta Zcash (ZEC). Zcash è una valuta digitale per pagamenti resistenti alla censura, sicuri e privati.",
+    "featuredSection": "Risorse in evidenza",
+    "latestUpdates": "Ultimi aggiornamenti",
+    "getInvolved": "Partecipa",
+    "exploreEcosystem": "Esplora l'ecosistema",
+    "exploreZcash": "Esplora Zcash",
+    "cards": {
+      "startHere": {
+        "title": "Inizia da qui",
+        "content": "Scopri cos'è Zcash e quali sono gli usi di ZEC"
+      },
+      "pickWallet": {
+        "title": "Scegli un wallet",
+        "content": "Trova il wallet Zcash adatto alle tue esigenze"
+      },
+      "useZecPrivately": {
+        "title": "Usa ZEC in modo privato",
+        "content": "Impara a usare le funzionalità di privacy di Zcash"
+      }
+    }
+  },
+  "visualizer": {
+    "title": "Visualizer Zcash",
+    "description": "Strumenti educativi interattivi per capire la tecnologia di privacy, l'infrastruttura e le prove a conoscenza zero di Zcash",
+    "playAll": "Riproduci tutti i visualizer",
+    "basic": "Base",
+    "basicDescription": "Concetti fondamentali e funzionalità essenziali di Zcash",
+    "advanced": "Avanzato",
+    "advancedDescription": "Approfondimenti tecnici su crittografia, consenso e infrastruttura",
+    "contributors": "Contributori",
+    "contributorsDescription": "Modi per contribuire all'ecosistema Zcash e ottenere ricompense"
+  },
+  "dao": {
+    "title": "ZecHub DAO",
+    "description": "Governance decentralizzata per ZecHub",
+    "proposals": "Proposte",
+    "vote": "Vota",
+    "createProposal": "Crea proposta",
+    "activeProposals": "Proposte attive",
+    "pastProposals": "Proposte passate"
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -90,7 +90,7 @@ export default function RootLayout({
                 new google.translate.TranslateElement(
                   {
                     pageLanguage: 'en',
-                    includedLanguages: 'en,fr,de,es,pt,ar,zh-CN,hi,ru,ja,ko,tr,uk,sw,yo,ig,ak,ee',
+                    includedLanguages: 'en,fr,de,it,es,pt,ar,zh-CN,hi,ru,ja,ko,tr,uk,sw,yo,ig,ak,ee',
                     layout: google.translate.TranslateElement.InlineLayout.HORIZONTAL,
                     autoDisplay: false,
                   },

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -22,6 +22,7 @@ export const LANGUAGES: Language[] = [
   { code: 'es',  label: 'Spanish',    nativeLabel: 'Español',    flag: '🇪🇸', googleCode: 'es'    },
   { code: 'fr',  label: 'French',     nativeLabel: 'Français',   flag: '🇫🇷', googleCode: 'fr'    },
   { code: 'de',  label: 'German',     nativeLabel: 'Deutsch',    flag: '🇩🇪', googleCode: 'de'    },
+  { code: 'it',  label: 'Italian',    nativeLabel: 'Italiano',   flag: '🇮🇹', googleCode: 'it'    },
   { code: 'pt',  label: 'Portuguese', nativeLabel: 'Português',  flag: '🇧🇷', googleCode: 'pt'    },
   { code: 'ar',  label: 'Arabic',     nativeLabel: 'العربية',    flag: '🇸🇦', googleCode: 'ar',   dir: 'rtl' },
   { code: 'zh',  label: 'Chinese',    nativeLabel: '中文',        flag: '🇨🇳', googleCode: 'zh-CN' },

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -2,5 +2,5 @@ export type Locale = string;
 
 export const i18n = {
   defaultLocale: 'en' as Locale,
-  locales: ['en', 'es', 'fr', 'de', 'pt', 'ar', 'zh', 'hi', 'ru', 'ja', 'ko', 'tr', 'uk', 'sw', 'yo', 'ig', 'ak', 'ee'] as Locale[],
+  locales: ['en', 'es', 'fr', 'de', 'it', 'pt', 'ar', 'zh', 'hi', 'ru', 'ja', 'ko', 'tr', 'uk', 'sw', 'yo', 'ig', 'ak', 'ee'] as Locale[],
 } as const;

--- a/src/lib/getDictionary.ts
+++ b/src/lib/getDictionary.ts
@@ -7,6 +7,7 @@ const dictionaries: Record<string, () => Promise<Dictionary>> = {
   es: () => import('../../dictionaries/es.json').then((m) => (m && m.default) || m),
   de: () => import('../../dictionaries/de.json').then((m) => (m && m.default) || m),
   fr: () => import('../../dictionaries/fr.json').then((m) => (m && m.default) || m),
+  it: () => import('../../dictionaries/it.json').then((m) => (m && m.default) || m),
   ja: () => import('../../dictionaries/ja.json').then((m) => (m && m.default) || m),
   ru: () => import('../../dictionaries/ru.json').then((m) => (m && m.default) || m),
   zh: () => import('../../dictionaries/zh.json').then((m) => (m && m.default) || m),


### PR DESCRIPTION
## Summary

Adds Italian (`it / Italiano`) to the ZecHub Wiki language selector and i18n setup.

## Changes

- Added `dictionaries/it.json`
- Added Italian to the supported locale config
- Added Italian to the language selector
- Added Italian to the Google Translate included languages
- Added Italian dictionary loading support

## Notes

This PR is intentionally limited to Italian language support. Rendering and hydration fixes found during local preview were split into a separate PR.

## Testing

- Confirmed `Italiano` appears in the language selector
- Confirmed Italian can be selected from the language menu in local preview
- Validated `dictionaries/it.json` as valid JSON
- Ran `yarn build`; compilation and TypeScript passed, then build stopped while collecting page data because local env is missing `SUPABASE_URL` for `/api/ai`