### PR TITLE
Fix preview rendering issues

### DIFF
--- a/src/app/[...slug]/page.tsx
+++ b/src/app/[...slug]/page.tsx
@@ -3,6 +3,7 @@ import ResearchIndexGrid from "@/components/Research/ResearchIndexGrid";
 import SideMenu from "@/components/SideMenu/SideMenu";
 import { getFileContentCached, getRootCached } from "@/lib/authAndFetch";
 import { genMetadata, getBanner, getDynamicRoute } from "@/lib/helpers";
+import { normalizeMdx } from "@/lib/normalizeMdx";
 import { Metadata } from "next";
 import React, { Suspense } from "react";
 import { notFound } from "next/navigation";
@@ -111,7 +112,7 @@ export default async function Page(props: { params: Promise<{ slug: string[] }> 
   }
 
   // ← UPDATED: Now supports tables everywhere
-  const serializedSource = await serialize(String(markdown || ""), {
+  const serializedSource = await serialize(normalizeMdx(String(markdown || "")), {
     mdxOptions: {
       remarkPlugins: [remarkGfm],
     },

--- a/src/app/using-zcash/shielded-pools/page.tsx
+++ b/src/app/using-zcash/shielded-pools/page.tsx
@@ -2,6 +2,7 @@ import MdxContainer from "@/components/MdxContainer";
 import SideMenu from "@/components/SideMenu/SideMenu";
 import { getFileContentCached, getRootCached } from "@/lib/authAndFetch";
 import { genMetadata, getBanner } from "@/lib/helpers";
+import { normalizeMdx } from "@/lib/normalizeMdx";
 import { Metadata } from "next";
 import DynamicComponent from "next/dynamic";
 import { serialize } from 'next-mdx-remote/serialize';
@@ -29,7 +30,7 @@ export default async function Page() {
   const content = markdown ? markdown : "No Data or Wrong file";
 
   // ← This fixes the MDXRemote error
-  const mdxSource = await serialize(String(content), {});
+  const mdxSource = await serialize(normalizeMdx(String(content)), {});
 
   return (
     <MdxContainer

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -683,6 +683,11 @@ const Navigation = () => {
   const [openSearch, setOpenSearch] = useState(false);
   const [isOpen, setIsOpen] = useState(false);
   const [showShop, setShowShop] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
 
   useEffect(() => {
     const prefersDark = window.matchMedia("(prefers-color-scheme: dark)");
@@ -803,24 +808,37 @@ const Navigation = () => {
 	</div>
 
             {/* Mobile menu */}
-            <Sheet open={isOpen} onOpenChange={setIsOpen}>
-              <SheetTrigger className="xl:hidden" asChild>
+            {mounted ? (
+              <Sheet open={isOpen} onOpenChange={setIsOpen}>
+                <SheetTrigger className="xl:hidden" asChild>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="p-2 hover:bg-nav-hover-bg cursor-pointer hover:text-black dark:hover:text-white"
+                  >
+                    <Menu className="h-10 w-10" />
+                  </Button>
+                </SheetTrigger>
+
+                <SheetContent
+                  side="left"
+                  className="bg-nav-background border-nav-border min-h-screen w-[300px] sm:w-[350px] bg-slate-50 dark:bg-slate-900 z-201"
+                >
+                  <MobileNav closeMenu={() => setIsOpen(false)} />
+                </SheetContent>
+              </Sheet>
+            ) : (
+              <div className="xl:hidden">
                 <Button
                   variant="ghost"
                   size="sm"
                   className="p-2 hover:bg-nav-hover-bg cursor-pointer hover:text-black dark:hover:text-white"
+                  aria-label="Open menu"
                 >
                   <Menu className="h-10 w-10" />
                 </Button>
-              </SheetTrigger>
-
-              <SheetContent
-                side="left"
-                className="bg-nav-background border-nav-border min-h-screen w-[300px] sm:w-[350px] bg-slate-50 dark:bg-slate-900 z-201"
-              >
-                <MobileNav closeMenu={() => setIsOpen(false)} />
-              </SheetContent>
-            </Sheet>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/lib/normalizeMdx.ts
+++ b/src/lib/normalizeMdx.ts
@@ -1,0 +1,3 @@
+export function normalizeMdx(markdown: string): string {
+  return markdown.replace(/\sclass=/g, " className=");
+}


### PR DESCRIPTION
## Summary

Fixes two rendering issues found while previewing the wiki locally.

## Changes

- Normalizes remote MDX content that uses `class=` so it is serialized as React-compatible `className=`
- Applies the MDX normalization to the catch-all MDX route and the special Shielded Pools page
- Delays mounting the Radix mobile drawer until after client mount to avoid SSR/client `aria-controls` hydration mismatches

## Why

Some remote markdown pages include raw HTML headings with `class=` attributes. React warns because MDX renders them as JSX, where `className` is expected.

The navigation drawer also produced a dev hydration mismatch because Radix-generated ids differed between server-rendered HTML and the client.

## Testing

- Confirmed `/using-zcash/shielded-pools` renders locally
- Confirmed `/wallets` renders locally after a clean dev-server restart
- Confirmed the mobile menu still renders after client mount