### PR TITLE
Fix Google Translate English reset build error

### DIFF
--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -316,8 +316,10 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
 
     if (code === 'en') {
       currentLanguageRef.current = LANGUAGES[0];
-      resetGoogleTranslateToEnglish();
-      clearGTCookiesAndReload();
+      const widgetReady = resetGoogleTranslateToEnglish();
+      if (!widgetReady) {
+        clearGTCookies();
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- restore the guarded `clearGTCookies()` fallback when switching back to English
- remove the call to the undefined `clearGTCookiesAndReload()` identifier introduced by #538
- retain the MDX retranslation and current-language tracking changes from #538

## Root cause
Commit `7ae6b955` of #538 ("Stabilize repeated Google Translate selection") changed the English-selection call site to invoke `clearGTCookiesAndReload()`, but no such function exists anywhere in the repo — only `clearGTCookies()` is defined. The undefined identifier caused the production Next.js TypeScript build to fail at `src/context/LanguageContext.tsx:320`. This PR replaces the bad call with the original guarded `clearGTCookies()` pattern that #538's first commit (`ae0511dc`) preserved.

## Validation
- verified via grep that `src/context/LanguageContext.tsx` no longer references `clearGTCookiesAndReload` and that `clearGTCookies()` is defined and reachable
- Playwright Tests passed on the PR head
- ran `git diff --check` (whitespace/conflict-marker check only — not a build signal)
- attempted dependency installation for a full local build, but stopped while Yarn was materializing 129,352 dependency files; full build validation is deferred to deployment CI