### PR TITLE
i18n(dex): render locale-aware DexClient + add missing pages.dex keys

### DIFF
--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -486,6 +486,9 @@
       "bannerAlt": "wiki-banner"
     },
     "dex": {
+      "title": "Decentralised Exchanges",
+      "subtitle": "ZecHub does not endorse any particular Decentralised Exchange service, please do your own research.",
+      "centralised": "Centralised Swap platforms",
       "centralizedTitle": "Centralized Swap Platform Listing",
       "custodial": "Custodial Exchanges"
     },

--- a/dictionaries/it.json
+++ b/dictionaries/it.json
@@ -615,6 +615,9 @@
       }
     },
     "dex": {
+      "title": "Exchange decentralizzati",
+      "subtitle": "ZecHub non approva alcun servizio di exchange decentralizzato in particolare; fai le tue ricerche.",
+      "centralised": "Piattaforme di swap centralizzate",
       "custodial": "Exchange custodial",
       "centralizedTitle": "Elenco delle piattaforme di swap centralizzate"
     },

--- a/src/app/[locale]/dex/page.tsx
+++ b/src/app/[locale]/dex/page.tsx
@@ -1,65 +1,14 @@
 import { genMetadata } from "@/lib/helpers";
 import { Metadata } from "next";
-import Image from "next/image";
-import { Link } from "@/i18n/navigation";
-import { Card } from "@/components/Card/Card";
-import { decentralizedExchanges } from "@/constants/decentralizedExchanges";
+import DexClient from "./DexClient";
 
 export const metadata: Metadata = genMetadata({
   title: "Decentralised Exchanges",
   url: "https://zechub.wiki/using-zcash/dex",
 });
 
-const DecentralisedExchanges = () => {
-  return (
-    <div className="container mx-auto px-4 py-8">
-      <div className="flex justify-between items-center my-12 flex-col md:flex-row gap-6">
-        <h1 className="flex justify-center items-center text-3xl font-bold mb-4 md:mb-0 text-center">
-          <Image
-            src="https://i.ibb.co/bmS65xV/image-2024-02-03-173258092.png"
-            alt="Zcash Logo"
-            width={50}
-            height={50}
-            className="inline-block mr-3"
-          />
-          Decentralised Exchanges
-        </h1>
-
-        <div className="flex flex-col sm:flex-row gap-4">
-          <Link
-            href="/using-zcash/custodial-exchanges"
-            className="inline-flex py-2 px-4 btn-brand focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-sm text-center"
-          >
-            Custodial Exchanges
-          </Link>
-          <Link
-            href="/using-zcash/centralizedswaps"
-            className="inline-flex py-2 px-4 btn-brand focus:ring-4 focus:outline-none focus:ring-blue-300 rounded-sm text-center"
-          >
-            Centralised Swap platforms
-          </Link>
-        </div>
-      </div>
-
-      <p className="text-zinc-600 dark:text-zinc-400 text-lg max-w-3xl mb-12">
-        ZecHub does not endorse any particular Decentralised Exchange service.
-        Please do your own research (DYOR).
-      </p>
-
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-        {decentralizedExchanges.map((item) => (
-          <Card
-            key={item.title}
-            thumbnailImage={item.image}
-            description={item.description}
-            title={item.title}
-            url={item.url}
-            ctaLabel="Visit DEX →"
-          />
-        ))}
-      </div>
-    </div>
-  );
-};
+// Render the locale-aware client so the DEX page picks up dictionary strings
+// (pages.dex.*) instead of hardcoded English. Metadata stays server-rendered.
+const DecentralisedExchanges = () => <DexClient />;
 
 export default DecentralisedExchanges;


### PR DESCRIPTION
## Problem

The `/dex` route already had an i18n-ready `DexClient.tsx` (reads `pages.dex.*` from the dictionary), but `page.tsx` still rendered a **hardcoded-English** component and never used it. So `/it/dex` (and any future locale) showed English regardless of the active language.

Two gaps:
1. `page.tsx` rendered the old hardcoded markup instead of `DexClient`.
2. `DexClient` reads `pages.dex.title`, `pages.dex.subtitle`, `pages.dex.centralised` — which were **missing** from the dictionary (only `custodial` + `centralizedTitle` existed).

## Change

- **`page.tsx`** now renders `<DexClient />` (metadata stays server-rendered).
- **`dictionaries/en.json` + `it.json`** — added the three missing `pages.dex` keys (`title`, `subtitle`, `centralised`). Existing keys (`custodial`, `centralizedTitle` — the latter used by `using-zcash/centralizedswaps`) are preserved.

## Result

`/dex` now localizes: Italian renders Italian, English unchanged, and any locale without these keys falls back to English via `DexClient`'s `?? "…"` defaults.

## Scope note

This localizes one hardcoded route page. Sibling route pages (e.g. `dashboard`, `developers`, `governance-howto`) still render hardcoded English and can follow the same pattern in future PRs. `visual-identity` is intentionally excluded — it's a PDF flipbook viewer with no translatable body text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)