### PR TITLE
i18n polish: localized side-menu titles, payment-processor parser, ambassadors keys

### DIFF
--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -94,7 +94,12 @@
     "Zingo Labs": "Zingo Labs",
     "Zingolib and Zaino Tutorial": "Zingolib and Zaino Tutorial",
     "Zkool Multisig": "Zkool Multisig",
-    "Custodial Exchanges": "Custodial Exchanges"
+    "Custodial Exchanges": "Custodial Exchanges",
+    "Zcash Use Cases": "Zcash Use Cases",
+    "Zcash Tech": "Zcash Tech",
+    "Privacy Tools": "Privacy Tools",
+    "Zcash Social Media": "Zcash Social Media",
+    "Glossary & FAQ's": "Glossary & FAQ's"
   },
   "exploreMenu": {
     "Full Explore": "Full Explore",
@@ -1036,7 +1041,17 @@
       "tagProtocolDesign": "Protocol Design",
       "tagZeroKnowledge": "Zero Knowledge"
     },
-    "browseSidebar": "Browse the articles using the sidebar on the left 👈"
+    "browseSidebar": "Browse the articles using the sidebar on the left 👈",
+    "zcashGlobalAmbassadors": {
+      "title": "Zcash Global Ambassadors",
+      "description": "Zcash Global Ambassadors are community leaders dedicated to promoting privacy-focused cryptocurrency adoption and education worldwide. Each ambassador project focuses on building awareness and engagement within their respective regions.",
+      "activeProjectsHeading": "Active Global Ambassador Projects",
+      "projectSitesHeading": "Project Sites & Blogs",
+      "followOnX": "Follow on X/BS",
+      "projectSiteLabel": "Project Site",
+      "linkLabel": "Link",
+      "footerInfo": "The Zcash Global Ambassadors program supports community-led initiatives to promote privacy-focused technology adoption. Each ambassador project operates independently while contributing to the broader Zcash ecosystem."
+    }
   },
   "developers": {
     "quickStart": {

--- a/dictionaries/it.json
+++ b/dictionaries/it.json
@@ -94,7 +94,12 @@
     "Zingo Labs": "Zingo Labs",
     "Zingolib and Zaino Tutorial": "Tutorial Zingolib e Zaino",
     "Zkool Multisig": "Zkool Multisig",
-    "Custodial Exchanges": "Exchange custodial"
+    "Custodial Exchanges": "Exchange custodial",
+    "Zcash Use Cases": "Casi d'uso di Zcash",
+    "Zcash Tech": "Tecnologia Zcash",
+    "Privacy Tools": "Strumenti per la privacy",
+    "Zcash Social Media": "Social media di Zcash",
+    "Glossary & FAQ's": "Glossario e FAQ"
   },
   "exploreMenu": {
     "Full Explore": "Esplora tutto",
@@ -726,7 +731,17 @@
       "tagProtocolDesign": "Progettazione del protocollo",
       "tagZeroKnowledge": "Zero Knowledge"
     },
-    "browseSidebar": "Sfoglia gli articoli usando la barra laterale a sinistra 👈"
+    "browseSidebar": "Sfoglia gli articoli usando la barra laterale a sinistra 👈",
+    "zcashGlobalAmbassadors": {
+      "title": "Ambasciatori globali di Zcash",
+      "description": "Gli Ambasciatori globali di Zcash sono leader della community impegnati a promuovere nel mondo l'adozione e la conoscenza delle criptovalute incentrate sulla privacy. Ogni progetto degli ambasciatori si concentra sullo sviluppo della consapevolezza e del coinvolgimento nelle rispettive aree geografiche.",
+      "activeProjectsHeading": "Progetti attivi degli Ambasciatori globali",
+      "projectSitesHeading": "Siti e blog dei progetti",
+      "followOnX": "Segui su X/BS",
+      "projectSiteLabel": "Sito del progetto",
+      "linkLabel": "Link",
+      "footerInfo": "Il programma Zcash Global Ambassadors sostiene iniziative guidate dalla community per promuovere l'adozione di tecnologie incentrate sulla privacy. Ogni progetto degli ambasciatori opera in modo indipendente, contribuendo al tempo stesso al più ampio ecosistema di Zcash."
+    }
   },
   "components": {
     "newsletter": {

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -96,7 +96,7 @@ const SideMenu = ({ folder, roots }: MenuProps) => {
           isMenuOpen ? "block mt-7" : "hidden xl:block"
         }`}
       >
-        <h1 className="text-4xl font-bold mb-6"> {fold}: </h1>
+        <h1 className="text-4xl font-bold mb-6"> {chromeLabel(fold)}: </h1>
         <div>
           <ul>
             {root.map((item: any, i: any) => {

--- a/src/lib/parseProcessorMarkdown.ts
+++ b/src/lib/parseProcessorMarkdown.ts
@@ -29,12 +29,14 @@ export function parseProcessorMarkdown(md: string) {
       }
     }
 
-    // Parse other fields
-    const supportTypeMatch = lines[1]?.match(/- \*\*Support Type\*\*: (.*)/);
-    const descriptionMatch = lines[2]?.match(/- \*\*Description\*\*: (.*)/);
-    
+    // Parse other fields by POSITION with a generic bold label, so translated
+    // field labels (e.g. "Tipo di supporto"/"Descrizione") still parse — the
+    // parser must not depend on English label text.
+    const supportTypeMatch = lines[1]?.match(/- \*\*[^*]+\*\*:\s*(.*)/);
+    const descriptionMatch = lines[2]?.match(/- \*\*[^*]+\*\*:\s*(.*)/);
+
     // Get URL from URL line if not already set from title
-    const urlLineMatch = lines[3]?.match(/- \*\*URL\*\*: \[.*?\]\((.*?)\)/);
+    const urlLineMatch = lines[3]?.match(/- \*\*[^*]+\*\*:\s*\[.*?\]\((.*?)\)/);
     if (!url && urlLineMatch) {
       url = urlLineMatch[1];
     }


### PR DESCRIPTION
Three locale bugs surfaced on the live Italian site. All fixes are locale-agnostic (benefit every curated locale).

### 1. Side-menu section titles never localized
`SideMenu` rendered the section header as `{fold}` — raw English from `getName()` — even though `menuLabels` already had the localized values. Now renders `chromeLabel(fold)` (localized, English fallback). Added the missing section keys to `menuLabels` (en + it): **Zcash Use Cases, Zcash Tech, Privacy Tools, Zcash Social Media, Glossary & FAQ's**.

### 2. `/payment-processors` blank cards in non-English locales
`parseProcessorMarkdown` hard-matched the **English** field labels `- **Support Type**:` / `- **Description**:` / `- **URL**:`. Translated corpora localize those labels (e.g. `Tipo di supporto`, `Descrizione`), so nothing parsed → empty cards. Now matches the value by position with a generic bold label, independent of label language. (Positional layout was already the parser's design; only the label text is now language-agnostic.)

### 3. `zcash-global-ambassadors` un-localizable
The `pages.zcashGlobalAmbassadors.*` keys were absent from **every** dictionary, so the page always used its hardcoded English fallbacks. Added the 8 keys to `en.json` (source) + `it.json` (Italian).

### Not included (separate)
Other locales (fr/es/pt/de/ar/zh) will pick up the section-title + parser fixes automatically; their `zcashGlobalAmbassadors` translations can be added to their dictionaries in a follow-up (they fall back to English until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)