### PR TITLE
i18n: localize dex/ambassador card content + ambassador map chrome

### DIFF
--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -495,7 +495,20 @@
       "subtitle": "ZecHub does not endorse any particular Decentralised Exchange service, please do your own research.",
       "centralised": "Centralised Swap platforms",
       "centralizedTitle": "Centralized Swap Platform Listing",
-      "custodial": "Custodial Exchanges"
+      "custodial": "Custodial Exchanges",
+      "exchanges": {
+        "Near-intents": "Fast exchange with the support of NEAR. Make deposits, sell, swap including popular TRUMP, MELANIA, BERA and other memes",
+        "Nativeswap": "Native Cross-Chain Trading Without Barriers via Maya Protocol. Trade directly on-chain without bridges or wrapped tokens - enjoy industry low fees and complete asset control.",
+        "Firo DEX": "Trustless decentralized swaps using atomic swaps with FiroDEX!.",
+        "LeoDEX": "A crosschain crypto swapping interface for Maya Protocol, Thorchain, ChainFlip and Rango. BTC, ETH, RUNE, DASH, LTC & More",
+        "Bison Wallet": "Trade crypto peer-to-peer. No trading fees. No KYC.",
+        "THORSwap": "Cross-chain DEX powered by THORChain, enabling native swaps between Bitcoin, Ethereum, and other major assets without wrapped tokens.",
+        "Router Protocol": "Cross-chain liquidity transport layer that allows seamless asset and data transfer between multiple blockchains.",
+        "Peer": "Decentralized peer-to-peer exchange enabling direct crypto transactions with enhanced privacy and user control.",
+        "RocketX": "Hybrid DEX aggregator enabling cross-chain swaps across multiple blockchains with optimal routing and competitive rates.",
+        "THORChain": "Decentralized Layer 1 cross-chain exchange. Swap native assets like ZEC, BTC, and ETH directly without bridges, wrapped tokens, or intermediaries.",
+        "Loofta": "Non-custodial private payment and swap platform. Send and receive crypto privately across chains, with Zcash as the settlement layer for enhanced financial privacy."
+      }
     },
     "usingZcash": {
       "blockchainExplorers": {
@@ -1050,7 +1063,27 @@
       "followOnX": "Follow on X/BS",
       "projectSiteLabel": "Project Site",
       "linkLabel": "Link",
-      "footerInfo": "The Zcash Global Ambassadors program supports community-led initiatives to promote privacy-focused technology adoption. Each ambassador project operates independently while contributing to the broader Zcash ecosystem."
+      "footerInfo": "The Zcash Global Ambassadors program supports community-led initiatives to promote privacy-focused technology adoption. Each ambassador project operates independently while contributing to the broader Zcash ecosystem.",
+      "mapTitle": "Zcash Ambassador Map",
+      "mapSubtitle": "Community-led Zcash advocacy across {count} active communities.",
+      "globeView": "Globe view",
+      "mapView": "Map view",
+      "loadError": "Could not load ambassador data.",
+      "projects": {
+        "Zcash Korea": "Zcash community and advocacy in Korea",
+        "Zcash Russia": "Zcash community and advocacy in Russia",
+        "Zcash Arabia": "Zcash community and advocacy in Arabic-speaking region",
+        "Zcash Brazil": "Zcash community and advocacy in Brazil",
+        "Zcash Ghana": "Zcash community and advocacy in Ghana",
+        "Zcash Español": "Zcash community and advocacy in Spanish-speaking region",
+        "Zcash Nigeria": "Zcash community and advocacy in Nigeria",
+        "Zcash Ukraine": "Zcash community and advocacy in Ukraine",
+        "Zcash Turkey": "Zcash community and advocacy in Turkey",
+        "Zcash India": "Zcash community and advocacy in India",
+        "Zcash East Africa": "Zcash East Africa is dedicated to promoting digital privacy, financial freedom, and blockchain innovation through education, community events, technical workshops, and ecosystem development. The initiative aims to create a regional hub where individuals can explore privacy enhancing technologies, learn about zero knowledge proofs, and participate in the growing global Zcash network.",
+        "Zcash South Africa": "Privacy🛡️. Freedom. Zcash 🦓 Community for South African region"
+      },
+      "globeTitle": "Zcash Ambassador Globe"
     }
   },
   "developers": {

--- a/dictionaries/it.json
+++ b/dictionaries/it.json
@@ -624,7 +624,20 @@
       "subtitle": "ZecHub non approva alcun servizio di exchange decentralizzato in particolare; fai le tue ricerche.",
       "centralised": "Piattaforme di swap centralizzate",
       "custodial": "Exchange custodial",
-      "centralizedTitle": "Elenco delle piattaforme di swap centralizzate"
+      "centralizedTitle": "Elenco delle piattaforme di swap centralizzate",
+      "exchanges": {
+        "Near-intents": "Scambio rapido con il supporto di NEAR. Effettua depositi, vendi e fai swap, inclusi i popolari TRUMP, MELANIA, BERA e altri meme token",
+        "Nativeswap": "Trading cross-chain nativo senza barriere tramite Maya Protocol. Fai trading direttamente on-chain senza bridge né wrapped token: approfitta di commissioni tra le più basse del settore e del pieno controllo dei tuoi asset.",
+        "Firo DEX": "Swap decentralizzati trustless tramite atomic swap con FiroDEX!.",
+        "LeoDEX": "Un'interfaccia di swap crypto cross-chain per Maya Protocol, Thorchain, ChainFlip e Rango. BTC, ETH, RUNE, DASH, LTC e altro",
+        "Bison Wallet": "Fai trading crypto peer-to-peer. Nessuna commissione di trading. Nessun KYC.",
+        "THORSwap": "DEX cross-chain basato su THORChain, che consente swap nativi tra Bitcoin, Ethereum e altri asset principali senza wrapped token.",
+        "Router Protocol": "Layer di trasporto della liquidità cross-chain che consente il trasferimento fluido di asset e dati tra più blockchain.",
+        "Peer": "Exchange peer-to-peer decentralizzato che consente transazioni crypto dirette con maggiore privacy e controllo da parte dell'utente.",
+        "RocketX": "Aggregatore DEX ibrido che consente swap cross-chain su più blockchain con routing ottimale e tassi competitivi.",
+        "THORChain": "Exchange cross-chain decentralizzato Layer 1. Scambia asset nativi come ZEC, BTC ed ETH direttamente senza bridge, wrapped token o intermediari.",
+        "Loofta": "Piattaforma non-custodial per pagamenti privati e swap. Invia e ricevi crypto in modo privato tra diverse chain, con Zcash come layer di regolamento per una maggiore privacy finanziaria."
+      }
     },
     "visualizer": {
       "title": "Visualizzatori Zcash",
@@ -740,7 +753,27 @@
       "followOnX": "Segui su X/BS",
       "projectSiteLabel": "Sito del progetto",
       "linkLabel": "Link",
-      "footerInfo": "Il programma Zcash Global Ambassadors sostiene iniziative guidate dalla community per promuovere l'adozione di tecnologie incentrate sulla privacy. Ogni progetto degli ambasciatori opera in modo indipendente, contribuendo al tempo stesso al più ampio ecosistema di Zcash."
+      "footerInfo": "Il programma Zcash Global Ambassadors sostiene iniziative guidate dalla community per promuovere l'adozione di tecnologie incentrate sulla privacy. Ogni progetto degli ambasciatori opera in modo indipendente, contribuendo al tempo stesso al più ampio ecosistema di Zcash.",
+      "mapTitle": "Mappa degli Ambasciatori Zcash",
+      "mapSubtitle": "Promozione di Zcash guidata dalla community in {count} community attive.",
+      "globeView": "Vista globo",
+      "mapView": "Vista mappa",
+      "loadError": "Impossibile caricare i dati degli ambasciatori.",
+      "projects": {
+        "Zcash Korea": "Community e promozione di Zcash in Corea",
+        "Zcash Russia": "Community e promozione di Zcash in Russia",
+        "Zcash Arabia": "Community e promozione di Zcash nella regione di lingua araba",
+        "Zcash Brazil": "Community e promozione di Zcash in Brasile",
+        "Zcash Ghana": "Community e promozione di Zcash in Ghana",
+        "Zcash Español": "Community e promozione di Zcash nella regione di lingua spagnola",
+        "Zcash Nigeria": "Community e promozione di Zcash in Nigeria",
+        "Zcash Ukraine": "Community e promozione di Zcash in Ucraina",
+        "Zcash Turkey": "Community e promozione di Zcash in Turchia",
+        "Zcash India": "Community e promozione di Zcash in India",
+        "Zcash East Africa": "Zcash East Africa si dedica a promuovere la privacy digitale, la libertà finanziaria e l'innovazione blockchain attraverso formazione, eventi per la community, workshop tecnici e sviluppo dell'ecosistema. L'iniziativa mira a creare un hub regionale in cui le persone possano esplorare le tecnologie per la tutela della privacy, conoscere le prove a conoscenza zero e partecipare alla crescente rete globale di Zcash.",
+        "Zcash South Africa": "Privacy🛡️. Libertà. Community Zcash 🦓 per la regione del Sudafrica"
+      },
+      "globeTitle": "Globo degli Ambasciatori di Zcash"
     }
   },
   "components": {

--- a/src/app/[locale]/dex/DexClient.tsx
+++ b/src/app/[locale]/dex/DexClient.tsx
@@ -40,7 +40,7 @@ export default function DexClient() {
         {decentralizedExchanges.map((itm, i) => (
           <Card
             thumbnailImage={itm.image}
-            description={itm.description}
+            description={t?.pages?.dex?.exchanges?.[itm.title] ?? itm.description}
             title={itm.title}
             url={itm.url}
             key={itm.title + "_" + Math.random() / i}

--- a/src/app/[locale]/zcash-global-ambassadors/GlobalAmbassadorsClient.tsx
+++ b/src/app/[locale]/zcash-global-ambassadors/GlobalAmbassadorsClient.tsx
@@ -44,10 +44,12 @@ function AmbassadorBanner({
 // ── Card (now with modern pop-out effect) ───────────────────────────────────
 function AmbassadorCard({
   project,
+  description,
   followLabel,
   projectSiteLabel,
 }: {
   project: (typeof ambassadorProjects)[number];
+  description: string;
   followLabel: string;
   projectSiteLabel: string;
 }) {
@@ -72,7 +74,7 @@ function AmbassadorCard({
 
         {/* Description */}
         <p className="text-sm text-muted-foreground flex-1 leading-relaxed">
-          {project.description}
+          {description}
         </p>
 
         {/* CTAs */}
@@ -154,6 +156,10 @@ export default function GlobalAmbassadorsClient() {
               <AmbassadorCard
                 key={getProjectKey(project)}
                 project={project}
+                description={
+                  t?.pages?.zcashGlobalAmbassadors?.projects?.[project.name] ??
+                  project.description
+                }
                 followLabel={followLabel}
                 projectSiteLabel={projectSiteLabel}
               />

--- a/src/app/[locale]/zcash-global-ambassadors/map/GlobalAmbassadorsMap.tsx
+++ b/src/app/[locale]/zcash-global-ambassadors/map/GlobalAmbassadorsMap.tsx
@@ -11,6 +11,7 @@ import Globe from "./Globe";
 import { Globe2, Map as MapIcon } from "lucide-react";
 import { PinDetails } from "./pin-details";
 import { StatsBar } from "./stats-bar";
+import { useLanguage } from "@/context/LanguageContext";
 import "./style.css";
 
 type ViewMode = "globe" | "map";
@@ -48,6 +49,8 @@ interface GeoJSONData {
 }
 
 export default function GlobalAmbassadorsMap() {
+  const { t } = useLanguage();
+  const amb = t?.pages?.zcashGlobalAmbassadors;
   const mapContainRef = useRef<HTMLDivElement>(null);
   const mapRef = useRef<any>(null);
   const markersRef = useRef<any[]>([]);
@@ -86,7 +89,7 @@ export default function GlobalAmbassadorsMap() {
         setLoading(false);
       })
       .catch((err) => {
-        setError("Could not load ambassador data.");
+        setError(amb?.loadError ?? "Could not load ambassador data.");
         setLoading(false);
         console.error(err);
       });
@@ -332,7 +335,9 @@ export default function GlobalAmbassadorsMap() {
                   lineHeight: 1.1,
                 }}
               >
-                Zcash Ambassador {viewMode === "globe" ? "Globe" : "Map"}
+                {viewMode === "globe"
+                  ? (amb?.globeTitle ?? "Zcash Ambassador Globe")
+                  : (amb?.mapTitle ?? "Zcash Ambassador Map")}
               </h1>
               <p
                 style={{
@@ -343,8 +348,11 @@ export default function GlobalAmbassadorsMap() {
                   lineHeight: 1.6,
                 }}
               >
-                Community-led Zcash advocacy across {ambassadors.length}{" "}
-                active communities.
+                {(amb?.mapSubtitle ??
+                  "Community-led Zcash advocacy across {count} active communities.").replace(
+                  "{count}",
+                  String(ambassadors.length),
+                )}
               </p>
             </div>
 
@@ -368,9 +376,9 @@ export default function GlobalAmbassadorsMap() {
                   <button
                     key={mode}
                     onClick={() => setViewMode(mode)}
-                    title={mode === "globe" ? "Globe view" : "Map view"}
+                    title={mode === "globe" ? (amb?.globeView ?? "Globe view") : (amb?.mapView ?? "Map view")}
                     aria-pressed={isActive}
-                    aria-label={mode === "globe" ? "Globe view" : "Map view"}
+                    aria-label={mode === "globe" ? (amb?.globeView ?? "Globe view") : (amb?.mapView ?? "Map view")}
                     style={{
                       display: "inline-flex",
                       alignItems: "center",


### PR DESCRIPTION
Follow-up to #623 (merged): that PR localized the page chrome; this one localizes the **card data** and the **map** on the two hardcoded route pages so they're fully translated, not just their headings.

### Changes
- **`/dex`** — exchange card **descriptions** now resolve via `pages.dex.exchanges[title]` (English data as fallback).
- **`/zcash-global-ambassadors`** — project card **descriptions** via `pages.zcashGlobalAmbassadors.projects[name]`; the **map** title (Globe/Map — kept dynamic), subtitle (with live `{count}`), view-toggle labels, and load-error message are all localized.
- Card **titles/names** are left verbatim (proper nouns, e.g. "Near-intents", "Zcash Korea").
- Adds the `en` + `it` translations for all of the above.

All strings are locale-agnostic; the other locales carry the matching keys in their own language PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)