### PR TITLE
privacy: baseline security response headers (1/4)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -58,6 +58,33 @@ const nextConfig = {
       },
     ];
   },
+  async headers() {
+    // Baseline security headers. These are all safe to enforce immediately and
+    // change no rendering behaviour. A full Content-Security-Policy (and its
+    // frame-ancestors) is deliberately deferred to a later PR, once the
+    // third-party asset/data sources have been localized.
+    const baseline = [
+      // Leak only the origin (never the full path) to cross-origin destinations.
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      // Never let a browser MIME-sniff a response into an executable type.
+      { key: "X-Content-Type-Options", value: "nosniff" },
+      // Disable powerful features the wiki never uses (also opts out of FLoC/Topics).
+      {
+        key: "Permissions-Policy",
+        value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+      },
+    ];
+    return [
+      { source: "/:path*", headers: baseline },
+      {
+        // Clickjacking protection everywhere EXCEPT the embeddable widget under
+        // /embed (and its locale-prefixed form /xx/embed), which is designed to
+        // be framed by third-party sites.
+        source: "/((?!(?:[a-z]{2}/)?embed(?:/|$)).*)",
+        headers: [{ key: "X-Frame-Options", value: "DENY" }],
+      },
+    ];
+  },
 
   // Force correct project root (avoids picking parent package-lock.json)
   turbopack: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -64,14 +64,24 @@ const nextConfig = {
     // frame-ancestors) is deliberately deferred to a later PR, once the
     // third-party asset/data sources have been localized.
     const baseline = [
-      // Leak only the origin (never the full path) to cross-origin destinations.
-      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+      // Send no Referer to any destination. Modern browsers already default to
+      // strict-origin-when-cross-origin, so that value was a no-op vs. defaults
+      // and still told every outbound host the reader came from ZecHub. For an
+      // at-risk-reader threat model, no-referrer is the coherent default.
+      { key: "Referrer-Policy", value: "no-referrer" },
       // Never let a browser MIME-sniff a response into an executable type.
       { key: "X-Content-Type-Options", value: "nosniff" },
       // Disable powerful features the wiki never uses (also opts out of FLoC/Topics).
       {
         key: "Permissions-Policy",
         value: "camera=(), microphone=(), geolocation=(), browsing-topics=()",
+      },
+      // On a first http:// visit a hostile network can observe/modify before the
+      // HTTPS redirect; HSTS closes that gap. Assumes all subdomains are always
+      // HTTPS (verify before relying on includeSubDomains/preload).
+      {
+        key: "Strict-Transport-Security",
+        value: "max-age=63072000; includeSubDomains; preload",
       },
     ];
     return [

--- a/src/lib/ai/env.ts
+++ b/src/lib/ai/env.ts
@@ -19,9 +19,28 @@ function getOptionalEnv(key: string): string | undefined {
   return value || undefined;
 }
 
+/** True only when every Supabase var required for vector search is present. */
+export function hasSupabaseEnv(): boolean {
+  return required.every((key) => Boolean(process.env[key]));
+}
+
+/**
+ * Lazy accessors. Reading a required Supabase value still throws when it is
+ * missing, but only at call time (request handling) — importing this module
+ * never throws, so `next build` and every non-AI route work without Supabase
+ * credentials configured.
+ */
 export const aiEnv = {
-  OPENAI_API_KEY: getOptionalEnv("OPENAI_API_KEY"),
-  SUPABASE_URL: getEnv("SUPABASE_URL"),
-  SUPABASE_ANON_KEY: getEnv("SUPABASE_ANON_KEY"),
-  SUPABASE_SERVICE_ROLE_KEY: getEnv("SUPABASE_SERVICE_ROLE_KEY"),
+  get OPENAI_API_KEY(): string | undefined {
+    return getOptionalEnv("OPENAI_API_KEY");
+  },
+  get SUPABASE_URL(): string {
+    return getEnv("SUPABASE_URL");
+  },
+  get SUPABASE_ANON_KEY(): string {
+    return getEnv("SUPABASE_ANON_KEY");
+  },
+  get SUPABASE_SERVICE_ROLE_KEY(): string {
+    return getEnv("SUPABASE_SERVICE_ROLE_KEY");
+  },
 } as const;

--- a/src/lib/ai/vectorSearch.ts
+++ b/src/lib/ai/vectorSearch.ts
@@ -6,6 +6,7 @@ import {
   getOpenAIClient,
   hasOpenAIApiKey,
 } from "./openai";
+import { hasSupabaseEnv } from "./env";
 import { getSupabaseAdminClient } from "./supabase";
 import type { RetrievedDocChunk } from "./types";
 
@@ -171,6 +172,10 @@ export interface SearchDocsResult {
 // Pre-warm the embedding cache as soon as this module is first imported.
 (function prewarm() {
   if (_cache.data || _cache.promise) return;
+  // Skip when Supabase creds are absent (e.g. `next build` without secrets, or
+  // a deploy where the AI assistant is disabled) — importing this module must
+  // never throw or hit the network.
+  if (!hasSupabaseEnv()) return;
   const supabase = getSupabaseAdminClient();
   loadEmbeddingCache(supabase).catch((err) =>
     console.error("[vectorSearch] prewarm failed:", err)


### PR DESCRIPTION
## PR 1 of 4 — Baseline security headers

Part of a privacy-hardening series for the at-risk-reader threat model (journalist / activist / hostile jurisdiction). **No visible change.**

### What this does
- Adds an `async headers()` block to `next.config.mjs`:
  - `Referrer-Policy: no-referrer`
  - `X-Content-Type-Options: nosniff`
  - `Permissions-Policy: camera=(), microphone=(), geolocation=(), browsing-topics=()` (also opts out of Topics/FLoC)
  - `Strict-Transport-Security: max-age=63072000; includeSubDomains; preload`
  - `X-Frame-Options: DENY` everywhere **except** the embeddable `/embed` widget (and its `/xx/embed` locale form), which is meant to be framed.
- Enabling fix: `src/lib/ai/env.ts` → lazy getters + `hasSupabaseEnv()`, and `vectorSearch.ts` gates its pre-warm, so `next build` no longer crashes when Supabase secrets are absent (CI/preview/forks). The AI assistant now fails *closed* instead of crashing the site.

### Honest scope (please read before reviewing)
These headers are **defense-in-depth, not an egress control** — they block zero third-party requests. The only structural brake on third-party contact is an **enforced CSP**, which is deliberately deferred to a later PR (it must be validated on a preview once the third-party sources in PRs 2–4 are removed). An earlier draft called this set a "structural brake"; that claim is retracted.

### Known residuals (tracked, not fixed here)
- The `[a-z]{2}` embed-locale regex assumes 2-letter locales; it will silently make `/embed` non-framable for any future non-2-letter locale (`pt-BR`, `zh-CN`). All current locales are 2-letter. Should be derived from the actual locale list.
- `X-Frame-Options` can't scope *which* origins may frame the widget — only CSP `frame-ancestors` can (comes with the CSP PR).
- `HSTS` `includeSubDomains`/`preload` assume all subdomains are permanently HTTPS — verify before merge. Also confirm Vercel isn't already sending HSTS.

### Verification
`next.config.mjs` `headers()` executes and emits all five headers; embed exception verified via the source regex. Draft pending a Vercel-preview header check against the real deployed response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
