### PR TITLE
privacy: same-origin proxies for browser data fetches (3/4)

### DIFF
--- a/src/app/api/data-updated/route.ts
+++ b/src/app/api/data-updated/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Same-origin proxy for the GitHub "commits for a data file" call that charts
+// use to show a "last updated" date. Previously the browser hit
+// api.github.com directly (leaking which chart/data page was loaded, and
+// burning GitHub's 60 req/hr/IP unauthenticated limit). This route uses the
+// server-side GITHUB_TOKEN and caches aggressively (commit dates change rarely).
+//
+// The response is the GitHub commits array verbatim, so existing client parsing
+// (helpers.getLastUpdatedDate) is unchanged.
+const CACHE_CONTROL = "public, s-maxage=3600, stale-while-revalidate=86400";
+
+// Only allow reading commit history for in-repo data files.
+const PATH_RE = /^public\/data\/[A-Za-z0-9._/-]+\.json$/;
+
+function cached(body: unknown, status = 200) {
+  return NextResponse.json(body, {
+    status,
+    headers: { "Cache-Control": CACHE_CONTROL },
+  });
+}
+
+export async function GET(req: NextRequest) {
+  const path = req.nextUrl.searchParams.get("path");
+  if (!path || path.includes("..") || !PATH_RE.test(path)) {
+    return NextResponse.json({ error: "invalid path" }, { status: 400 });
+  }
+
+  const url =
+    `https://api.github.com/repos/ZecHub/zechub-wiki/commits` +
+    `?path=${encodeURIComponent(path)}&per_page=1`;
+
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "ZecHub-App",
+  };
+  const token = process.env.GITHUB_TOKEN;
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  try {
+    const upstream = await fetch(url, { headers, next: { revalidate: 3600 } });
+    if (!upstream.ok) {
+      // Degrade gracefully: an empty array makes getLastUpdatedDate return "N/A".
+      return cached([]);
+    }
+    return cached(await upstream.json());
+  } catch {
+    return cached([]);
+  }
+}

--- a/src/app/api/prices/simple/route.ts
+++ b/src/app/api/prices/simple/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// Same-origin proxy for CoinGecko's simple/price endpoint. Keeps the API key
+// server-side (out of the browser) and stops the visitor's browser from
+// contacting api.coingecko.com directly (which leaked "this browser is on a
+// Zcash tool/page now" to CoinGecko, including a 60s beacon). The upstream call
+// is cached so we make at most ~1 request/minute globally.
+const CG_BASE = "https://api.coingecko.com/api/v3/simple/price";
+
+const ALLOWED_PARAMS = new Set([
+  "ids",
+  "names",
+  "vs_currencies",
+  "include_market_cap",
+  "include_24hr_vol",
+  "include_24hr_change",
+]);
+
+const CACHE_CONTROL = "public, s-maxage=60, stale-while-revalidate=300";
+
+export async function GET(req: NextRequest) {
+  const out = new URLSearchParams();
+  for (const [key, value] of req.nextUrl.searchParams) {
+    if (ALLOWED_PARAMS.has(key)) out.set(key, value);
+  }
+  if (!out.has("vs_currencies")) out.set("vs_currencies", "usd");
+  if (!out.has("ids") && !out.has("names")) {
+    return NextResponse.json({ error: "missing ids or names" }, { status: 400 });
+  }
+
+  const headers: Record<string, string> = { accept: "application/json" };
+  const apiKey = process.env.COINGECKO_API_KEY;
+  if (apiKey) headers["x-cg-demo-api-key"] = apiKey;
+
+  try {
+    const upstream = await fetch(`${CG_BASE}?${out.toString()}`, {
+      headers,
+      next: { revalidate: 60 },
+    });
+    if (!upstream.ok) {
+      return NextResponse.json(
+        { error: `upstream ${upstream.status}` },
+        { status: 502 },
+      );
+    }
+    const data = await upstream.json();
+    return NextResponse.json(data, {
+      headers: { "Cache-Control": CACHE_CONTROL },
+    });
+  } catch {
+    return NextResponse.json({ error: "fetch failed" }, { status: 502 });
+  }
+}

--- a/src/components/Charts/Metric.tsx
+++ b/src/components/Charts/Metric.tsx
@@ -66,20 +66,12 @@ const CryptoMetrics = ({ selectedCoin }: { selectedCoin: string }) => {
         setLoading(true);
         setError(null);
 
-        // Fetch CoinGecko data
-        const options = {
-          method: "GET",
-          headers: {
-            accept: "application/json",
-            "x-cg-demo-api-key": "CG-C7uDKWaJaNy8ZTtVb6bWv19d",
-          },
-        };
-
+        // Fetch price data via the same-origin proxy (keeps the CoinGecko key
+        // server-side and the visitor's browser off api.coingecko.com).
         const response = await fetch(
-          `https://api.coingecko.com/api/v3/simple/price?vs_currencies=usd%2Cbtc&names=${encodeURIComponent(
+          `/api/prices/simple?vs_currencies=usd%2Cbtc&names=${encodeURIComponent(
             name.toLowerCase()
-          )}&include_market_cap=true&include_24hr_vol=true&include_24hr_change=true`,
-          options
+          )}&include_market_cap=true&include_24hr_vol=true&include_24hr_change=true`
         );
 
         if (!response.ok) {

--- a/src/components/Charts/SheetTreasuryTab.tsx
+++ b/src/components/Charts/SheetTreasuryTab.tsx
@@ -13,7 +13,8 @@ import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
 import { fetchTreasuryFromSheet } from "@/lib/parseTreasurySheet";
 
 // NEW: Live ZEC price from the exact same Blockchair API used on the main ZecHub dashboard
-const BLOCKCHAIR_ZEC_STATS_URL = "https://api.blockchair.com/zcash/stats";
+// Same-origin proxy (Blockchair key stays server-side) — see pages/api/blockchain-data.
+const BLOCKCHAIR_ZEC_STATS_URL = "/api/blockchain-data";
 
 const PIE_COLORS = [
   "#3b82f6",

--- a/src/components/HalvingMeter/halving-meter.tsx
+++ b/src/components/HalvingMeter/halving-meter.tsx
@@ -2,7 +2,8 @@
 import { useEffect, useState } from 'react';
 import type { RefObject } from 'react';
 
-const api = ['https://api.blockchair.com/zcash/stats'];
+// Same-origin proxy (Blockchair key stays server-side) — see pages/api/blockchain-data.
+const api = ['/api/blockchain-data'];
 
 function fetchData(url: any) {
   return new Promise((resolve, reject) => {

--- a/src/components/PrivacySet/PrivacySetVisualization.tsx
+++ b/src/components/PrivacySet/PrivacySetVisualization.tsx
@@ -21,8 +21,9 @@ const HEIGHT_YEAR_MAP = [
   { start: 2771015, end: Infinity, year: "2025" },
 ];
 
-const DATA_URL =
-  "https://raw.githubusercontent.com/ZecHub/zechub-wiki/main/public/data/zcash/transaction_summary.json";
+// Served same-origin from the in-repo copy (public/data/zcash/) instead of
+// fetching from raw.githubusercontent.com in the browser.
+const DATA_URL = "/data/zcash/transaction_summary.json";
 
 const PrivacySetVisualization: React.FC = () => {
   const [loading, setLoading] = useState(true);

--- a/src/components/visualizer/BuildShieldedTransaction/BuildShieldedTransactionContent.tsx
+++ b/src/components/visualizer/BuildShieldedTransaction/BuildShieldedTransactionContent.tsx
@@ -141,7 +141,7 @@ export function useZecPrice() {
     const fetchPrice = async () => {
       try {
         const res = await fetch(
-          "https://api.coingecko.com/api/v3/simple/price?ids=zcash&vs_currencies=usd",
+          "/api/prices/simple?ids=zcash&vs_currencies=usd",
           { cache: "no-store" }
         );
         const data = await res.json();

--- a/src/lib/chart/data-url.ts
+++ b/src/lib/chart/data-url.ts
@@ -15,11 +15,11 @@ export const DATA_URL = {
   issuanceUrl: "/data/zcash/issuance.json",
   zcashShieldedStatsUrl: "/data/zcash/shieldedStatsJSON.json",
   shieldedUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/shielded_supply.json",
+    "/api/data-updated?path=public/data/zcash/shielded_supply.json",
   namadaSupplyUrl: "/data/namada/namada_supply.json",
   blockchainInfoUrl: "/api/blockchain-info",
-  blockchairUrl:
-    "https://api.blockchair.com/zcash/stats?key=A___nd1AAQ1G2DSEi9xRDFbAYUjawP2d",
+  // Server-side proxy (key stays out of the browser) — see pages/api/blockchain-data.
+  blockchairUrl: "/api/blockchain-data",
   namadaRewardUrl: "/data/namada/namada_rewards_rate.json",
   blockFeesUrl: "/data/zcash/blockFeesZEC.json",
   networkSolpsUrl: "/data/zcash/networksolps.json",
@@ -29,44 +29,46 @@ export const DATA_URL = {
   miningPoolsDominanceUrl: "/api/mining-pools-dominance",
 } as const;
 
+// All "last updated" lookups go through the same-origin /api/data-updated proxy
+// (server-side GitHub token + caching) instead of the browser hitting
+// api.github.com directly.
 export const DATE_URL = {
   defaultUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/shielded_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/shielded_supply.json",
   sproutUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/sprout_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/sprout_supply.json",
   saplingUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/sapling_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/sapling_supply.json",
   orchardUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/orchard_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/orchard_supply.json",
   txsummaryUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/transaction_summary.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/transaction_summary.json",
   transparentSupplyUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/transparent_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/transparent_supply.json",
   netInflowsOutflowsUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/netinflowoutflow.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/netinflowoutflow.json",
   nodecountUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/nodecount.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/nodecount.json",
   difficultyUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/difficulty.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/difficulty.json",
   lockboxUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/lockbox.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/lockbox.json",
   ironwoodUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/ironwood_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/ironwood_supply.json",
   shieldedTxCountUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/shieldedtxcount.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/shieldedtxcount.json",
   issuanceUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/issuance.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/issuance.json",
   shieldedUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/shielded_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/shielded_supply.json",
   namadaSupplyUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/namada/namada_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/namada/namada_supply.json",
   blockchainInfoUrl: "/api/blockchain-info",
-  blockchairUrl:
-    "https://api.blockchair.com/zcash/stats?key=A___NwjLQ29USRVGxzBQd2QoFvxSRNSk",
+  blockchairUrl: "/api/blockchain-data",
   namadaRewardUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/namada/namada_rewards_rate.json&per_page=1",
+    "/api/data-updated?path=public/data/namada/namada_rewards_rate.json",
   zcashShieldedStatsUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/shieldedStatsJSON.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/shieldedStatsJSON.json",
   totalSupplyUrl:
-    "https://api.github.com/repos/ZecHub/zechub-wiki/commits?path=public/data/zcash/total_supply.json&per_page=1",
+    "/api/data-updated?path=public/data/zcash/total_supply.json",
 } as const;


### PR DESCRIPTION
## PR 3 of 4 — Same-origin proxies for browser data fetches

Part of the privacy-hardening series. Stops the browser from talking to CoinGecko, GitHub, `raw.githubusercontent`, and Blockchair; removes client-shipped API keys. **No visible change.**

### What this does
- **CoinGecko** (`Charts/Metric.tsx`, shielded-tx visualizer): new `src/app/api/prices/simple/route.ts` — allow-listed params, key held server-side (`COINGECKO_API_KEY`), cached (`revalidate: 60` + `s-maxage=60`). Removes the **hardcoded demo key** that shipped to every visitor. 60s refresh kept (polling own origin is fine).
- **GitHub "last updated" dates**: new `src/app/api/data-updated/route.ts` — path allow-list regex + `..` reject, server `GITHUB_TOKEN`, 1h cache, degrades to `[]`. All `DATE_URL`/`DATA_URL.shieldedUrl` entries repointed.
- **raw.githubusercontent**: `PrivacySetVisualization.tsx` now reads the same-origin `public/` copy.
- **Blockchair**: `HalvingMeter` + `SheetTreasuryTab` routed through the existing `/api/blockchain-data` proxy; **two hardcoded Blockchair keys deleted** from `data-url.ts`.

### ⚠️ Known gaps (documented, fixes deferred — reviewer input welcome)
- **Both proxies are unauthenticated, unbounded relays.** An attacker can vary `ids`/case/ordering (prices) or `path` (data-updated) to blow cache cardinality and **exhaust the demo key / GitHub token**. "≈1 req/min globally" is not guaranteed across serverless regions.
- `/api/data-updated` returns the full commits array (only a date is needed) and returns `[]`+200 on *every* failure, masking token expiry/outage/abuse.
- Follow-up fix: exact allow-lists derived from the chart definitions, param canonicalization + count/size caps, `{ updatedAt }`-only response, or preferably **build-time static snapshots** (no runtime proxy at all).
- Not SSRF — the upstream host/route are fixed; this is a quota/abuse concern, not request forgery.

### 🔑 Blocking follow-up (separate from this PR)
Deleting the keys from source does **not** revoke them — both Blockchair keys and the CoinGecko demo key are **live in public git history** (e.g. `beda3622`). They must be **revoked/rotated** for this PR to actually help. Tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
