### PR TITLE
hotfix: restore YouTube embeds (Referrer-Policy no-referrer → strict-origin-when-cross-origin)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -64,11 +64,14 @@ const nextConfig = {
     // frame-ancestors) is deliberately deferred to a later PR, once the
     // third-party asset/data sources have been localized.
     const baseline = [
-      // Send no Referer to any destination. Modern browsers already default to
-      // strict-origin-when-cross-origin, so that value was a no-op vs. defaults
-      // and still told every outbound host the reader came from ZecHub. For an
-      // at-risk-reader threat model, no-referrer is the coherent default.
-      { key: "Referrer-Policy", value: "no-referrer" },
+      // Send only the ORIGIN (scheme+host, never the path) to cross-origin
+      // destinations, and nothing on an HTTPS->HTTP downgrade. We do NOT use
+      // no-referrer: YouTube's embed player refuses to play (PlayabilityStatus
+      // ERROR -> "video player configuration error") when it receives no Referer,
+      // so no-referrer broke every embedded video site-wide. Origin-only is the
+      // right balance here — the origin is already visible to the network via
+      // DNS/TLS SNI, while the page path (the sensitive part) is still withheld.
+      { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
       // Never let a browser MIME-sniff a response into an executable type.
       { key: "X-Content-Type-Options", value: "nosniff" },
       // Disable powerful features the wiki never uses (also opts out of FLoC/Topics).


### PR DESCRIPTION
## Hotfix: restore YouTube embeds broken by `Referrer-Policy: no-referrer`

### Regression
PR #646 shipped `Referrer-Policy: no-referrer` site-wide. YouTube's embed player refuses to play when it receives **no** `Referer` — it returns `PlayabilityStatus: ERROR`, surfaced to users as **"Error 153 — video player configuration error."** This broke **every embedded video site-wide**, e.g. https://zechub.wiki/it/zcash-organizations/zcash-foundation (reported by a user).

### Evidence (verified directly against YouTube)
`GET https://www.youtube.com/embed/S3uGdNEMymI`:
- **no `Referer`** → `PlayabilityStatus: {status: "ERROR"}`
- **`Referer: https://zechub.wiki`** (origin only) → `PlayabilityStatus: {status: "OK"}`

### Fix
`Referrer-Policy: no-referrer` → **`strict-origin-when-cross-origin`**.
- Sends only the **origin** (`https://zechub.wiki`) to cross-origin destinations — never the page path — and nothing on an HTTPS→HTTP downgrade.
- Enough for YouTube to authorize playback; the sensitive part (the exact page a reader is on) is still withheld.
- The origin is already exposed to the network via DNS/TLS SNI, so origin-only referrer is a minimal, acceptable disclosure for the at-risk-reader threat model.
- All other baseline headers from #646 (`X-Content-Type-Options`, `Permissions-Policy`, `Strict-Transport-Security`, `X-Frame-Options`) are unchanged.

### Follow-up (separate)
The facade in #649 (`LiteYouTube.tsx`) hardcodes `referrerPolicy="no-referrer"` on its iframe — it would hit the same error once merged. That is being corrected on the #649 branch to `strict-origin-when-cross-origin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
