### PR TITLE
security(csp): add Content-Security-Policy in report-only mode

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -59,10 +59,55 @@ const nextConfig = {
     ];
   },
   async headers() {
-    // Baseline security headers. These are all safe to enforce immediately and
-    // change no rendering behaviour. A full Content-Security-Policy (and its
-    // frame-ancestors) is deliberately deferred to a later PR, once the
-    // third-party asset/data sources have been localized.
+    // Baseline security headers (safe to enforce; no rendering change). A full
+    // Content-Security-Policy ships alongside them in REPORT-ONLY mode: the
+    // browser reports violations (console + /api/csp-report) but blocks nothing,
+    // so we can watch a run and close gaps before enforcing. Allow-list notes:
+    //   script 'unsafe-inline'      — Next's inline bootstrap/streaming scripts
+    //   script 'wasm-unsafe-eval'   — zaddr_wasm_parser + Penumbra WASM modules
+    //   style  'unsafe-inline'      — styled-components + pervasive inline styles
+    //   img img.shields.io          — live edit/status badges (kept: privacy-
+    //                                 respecting + dynamic, never vendored)
+    //   img upload.wikimedia.org    — a few exchange logos (kept: privacy-respecting)
+    //   img i.ytimg.com             — YouTube thumbnails (Charts) [proxy candidate]
+    //   img i.postimg.cc            — images in generated DAO-proposal text
+    //   img ipfs.daodao.zone        — DAO logos (plain <img>) [proxy candidate]
+    //   img *.basemaps.cartocdn.com — Leaflet map tiles (consent-gated)
+    //   connect raw.githubusercontent — Namada params client fetch [proxy candidate]
+    //   media  free2z / jsdelivr    — hackathon demo videos (user-initiated)
+    //   frame  youtube(-nocookie)   — click-to-load video embeds
+    // CAVEATS for the enforce flip:
+    //   * frame-ancestors is IGNORED in Report-Only (per CSP spec) — the preview
+    //     yields NO signal for it, so validate /embed separately and give /embed
+    //     its own enforced policy WITHOUT frame-ancestors 'self'.
+    //   * This policy limits EGRESS, not XSS: 'unsafe-inline' (no nonce) + the
+    //     unsanitized rehypeRaw markdown pipeline mean injected inline script
+    //     still runs. Treat XSS via a sanitizer/nonce as separate follow-up work.
+    //   * Preview deploys inject the vercel.live toolbar (violates script/connect/
+    //     frame) — monitor a PRODUCTION deploy, or filter those out.
+    // To ENFORCE: rename the header to "Content-Security-Policy" (+ /embed carve-out).
+    const cspReportOnly = [
+      "default-src 'self'",
+      "base-uri 'self'",
+      "object-src 'none'",
+      "form-action 'self'",
+      "frame-ancestors 'self'",
+      "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'",
+      "style-src 'self' 'unsafe-inline'",
+      "img-src 'self' data: blob: https://i.ytimg.com https://i.postimg.cc https://*.basemaps.cartocdn.com https://img.shields.io https://upload.wikimedia.org https://ipfs.daodao.zone",
+      "font-src 'self' data:",
+      // raw.githubusercontent: the Namada protocol-parameters page fetches JSON
+      // client-side (candidate to proxy same-origin later).
+      "connect-src 'self' https://raw.githubusercontent.com",
+      "frame-src 'self' https://www.youtube-nocookie.com https://www.youtube.com",
+      // free2z / jsdelivr: hackathon submission demo videos (user-initiated).
+      "media-src 'self' https://free2z.cash https://cdn.jsdelivr.net",
+      "worker-src 'self' blob:",
+      "manifest-src 'self'",
+      "report-uri /api/csp-report",
+      "report-to csp-endpoint",
+    ].join("; ");
+
     const baseline = [
       // Send only the ORIGIN (scheme+host, never the path) to cross-origin
       // destinations, and nothing on an HTTPS->HTTP downgrade. We do NOT use
@@ -86,6 +131,12 @@ const nextConfig = {
         key: "Strict-Transport-Security",
         value: "max-age=63072000; includeSubDomains; preload",
       },
+      // Report-only CSP (policy built above). Blocks nothing yet — reports
+      // violations to the console and to /api/csp-report so we can watch a
+      // preview before flipping to the enforcing "Content-Security-Policy".
+      { key: "Content-Security-Policy-Report-Only", value: cspReportOnly },
+      // Declares the endpoint named by the report-to directive (Reporting API).
+      { key: "Reporting-Endpoints", value: 'csp-endpoint="/api/csp-report"' },
     ];
     return [
       { source: "/:path*", headers: baseline },

--- a/src/app/api/csp-report/route.ts
+++ b/src/app/api/csp-report/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// CSP violation sink. While the policy ships as Content-Security-Policy-Report-Only,
+// browsers POST here (report-uri / Reporting API) instead of blocking. We log a
+// compact one-liner per violation so gaps show up in the Vercel logs, then close
+// them before switching to the enforcing header. No storage, no PII beyond the
+// directive/URL the browser already reports.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const MAX_BODY = 16 * 1024; // ignore anything larger — this is a log sink, not an API
+const MAX_ENTRIES = 5; // cap log lines per request (anti log-amplification)
+const MAX_FIELD = 300; // truncate each logged field
+
+// Replace control chars (< 0x20 and DEL) with spaces so an attacker-controlled
+// URL in a report can't forge extra log lines, then truncate. Codepoint compare
+// (no regex) to keep the source free of literal control characters.
+function clean(v: unknown): string {
+  const s = String(v ?? "?");
+  let out = "";
+  for (const ch of s) {
+    const c = ch.codePointAt(0) ?? 0;
+    out += c < 0x20 || c === 0x7f ? " " : ch;
+    if (out.length >= MAX_FIELD) break;
+  }
+  return out;
+}
+
+function summarize(entry: any): string | null {
+  if (!entry || typeof entry !== "object") return null;
+  // Legacy report-uri shape: { "csp-report": {...} }
+  const r = entry["csp-report"] ?? entry.body ?? entry;
+  if (!r || typeof r !== "object") return null;
+  const directive = clean(r["effective-directive"] || r["violated-directive"] || r.effectiveDirective);
+  const blocked = clean(r["blocked-uri"] || r.blockedURL);
+  const doc = clean(r["document-uri"] || r.documentURL);
+  return `directive=${directive} blocked=${blocked} doc=${doc}`;
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    // Content-Length fast-reject before buffering (best-effort; platform also caps).
+    const len = Number(req.headers.get("content-length") || 0);
+    if (len > MAX_BODY) return new NextResponse(null, { status: 204 });
+    const raw = await req.text();
+    if (!raw || raw.length > MAX_BODY) return new NextResponse(null, { status: 204 });
+    const parsed = JSON.parse(raw);
+    // Reporting API sends an array of reports; report-uri sends a single object.
+    const entries = (Array.isArray(parsed) ? parsed : [parsed]).slice(0, MAX_ENTRIES);
+    for (const e of entries) {
+      const line = summarize(e);
+      if (line) console.warn(`[csp-report] ${line}`);
+    }
+  } catch {
+    // Malformed report — ignore; never error a beacon.
+  }
+  return new NextResponse(null, { status: 204 });
+}


### PR DESCRIPTION
## What / why

Adds a full **Content-Security-Policy**, shipped as **`Content-Security-Policy-Report-Only`** — the browser *reports* violations (console + `/api/csp-report`) but **blocks nothing**. This is the structural egress lock the header-only baseline couldn't provide, staged safely so we can watch a preview and close gaps before enforcing.

## Changes
- **`next.config.mjs`** — `cspReportOnly` policy + `Content-Security-Policy-Report-Only` and `Reporting-Endpoints` headers on every route.
  - `default-src 'self'`, `object-src 'none'`, `base-uri`/`form-action`/`frame-ancestors 'self'`.
  - Documented allow-list exceptions: `script-src` adds `'unsafe-inline'` (Next inline bootstrap) + `'wasm-unsafe-eval'` (zaddr/Penumbra WASM); `style-src 'unsafe-inline'` (styled-components + inline styles); `img-src` adds `i.ytimg.com` (YT thumbnails), `*.basemaps.cartocdn.com` (map tiles, consent-gated), `i.postimg.cc` (DAO-proposal text); `frame-src` adds `youtube(-nocookie).com`.
- **`src/app/api/csp-report/route.ts`** — minimal violation sink: logs one compact line per report (handles both `report-uri` and Reporting-API shapes), caps body size, never errors a beacon.

## Rollout plan
1. **This PR (report-only)** — zero behaviour change. Deploy, browse a preview for a few days, watch `/api/csp-report` in the Vercel logs.
2. **Enforce (follow-up)** — once the sink is clean: rename the header to `Content-Security-Policy`, and give `/embed` its own policy without `frame-ancestors 'self'` (it's meant to be framed).

## Coordination
The `img-src 'self'` baseline assumes images are same-origin — pairs with **#656** (self-hosted images). Merge after/with #656. Edits a different region of `next.config.mjs` than #656, so no conflict.

## Verification
Production `yarn build` green; `/api/csp-report` route registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)