### PR TITLE
Add Ironwood readiness indicator to wallet cards

### DIFF
--- a/src/components/FilterToggle.tsx
+++ b/src/components/FilterToggle.tsx
@@ -8,6 +8,7 @@ interface FilterToggleProps {
     Pools: Set<string>;
     "Wallet Support": Set<string>;
     Features: Set<string>;
+    Ironwood?: Set<string>;
   };
   activeFilters: string[];
   toggleFilter: (filterCategory: string, filterValue: string) => void;
@@ -22,7 +23,9 @@ const FilterToggle: React.FC<FilterToggleProps> = ({
 }) => {
   return (
     <div className="pb-6 imd:block flex flex-wrap justify-between">
-      {Object.entries(filters).map(([category, values]) => (
+      {Object.entries(filters)
+        .filter(([, values]) => values && values.size > 0)
+        .map(([category, values]) => (
         <div key={category}>
           <h4 className="text-xl font-bold mt-6 mb-3">{category}</h4>
           <div className="imd:block flex flex-wrap gap-2">

--- a/src/components/Wallet/WalletItem.tsx
+++ b/src/components/Wallet/WalletItem.tsx
@@ -19,6 +19,7 @@ interface WalletItemProps {
   tags: Tag[];
   likes: number;
   syncSpeed: string;
+  ironwood?: string;
   onLike: () => void;
   onDislike: () => void;
   error: string;
@@ -43,6 +44,27 @@ const categoryIcons = {
   Features: MdChecklist,
 };
 
+// NU6.3 "Ironwood" upgrade status → badge colors (status text comes from Wallets.md)
+const ironwoodBadgeStyles: { [key: string]: { pill: string; dot: string } } = {
+  "ready": {
+    pill: "bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300",
+    dot: "bg-emerald-500",
+  },
+  "in progress": {
+    pill: "bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300",
+    dot: "bg-amber-500",
+  },
+  "not ready": {
+    pill: "bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-300",
+    dot: "bg-rose-500",
+  },
+};
+
+const ironwoodFallbackStyle = {
+  pill: "bg-slate-200 text-slate-600 dark:bg-slate-700 dark:text-slate-300",
+  dot: "bg-slate-500",
+};
+
 const featureLinkMap: { [key: string]: string } = {
   "Orchard": "https://zechub.wiki/using-zcash/shielded-pools#orchard",
   "Sapling": "https://zechub.wiki/using-zcash/shielded-pools#sapling",
@@ -59,6 +81,7 @@ const WalletItem: React.FC<WalletItemProps> = ({
   logo,
   tags,
   syncSpeed,
+  ironwood,
   likes,
   onLike,
   onDislike,
@@ -143,6 +166,25 @@ const WalletItem: React.FC<WalletItemProps> = ({
             <Icon icon={OpenNew} className="inline-block ms-2" size="small" />
           </Link>
         </div>
+
+        {/* NU6.3 "Ironwood" readiness badge */}
+        {ironwood && (
+          <div className="mb-4 -mt-1">
+            <span
+              title="NU6.3 Ironwood network upgrade status"
+              className={`inline-flex items-center gap-1.5 px-3 py-1 text-xs font-semibold rounded-full ${
+                (ironwoodBadgeStyles[ironwood.toLowerCase()] ?? ironwoodFallbackStyle).pill
+              }`}
+            >
+              <span
+                className={`w-1.5 h-1.5 rounded-full ${
+                  (ironwoodBadgeStyles[ironwood.toLowerCase()] ?? ironwoodFallbackStyle).dot
+                }`}
+              />
+              Ironwood {ironwood}
+            </span>
+          </div>
+        )}
 
         {/* Devices + Pools (compact pills) */}
         {tags

--- a/src/components/Wallet/WalletList.tsx
+++ b/src/components/Wallet/WalletList.tsx
@@ -14,6 +14,7 @@ interface Wallet {
   operatingSystem: string[];
   walletSupport: string[];
   syncSpeed: string;
+  ironwood: string;
 }
 
 interface Props {
@@ -28,6 +29,7 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
     Pools: new Set<string>(),
     "Wallet Support": new Set<string>(),
     Features: new Set<string>(),
+    Ironwood: new Set<string>(),
   });
   const [likes, setLikes] = useState<{ [key: string]: number }>({});
   const [error, setError] = useState<{ [key: string]: string }>({});
@@ -53,6 +55,7 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
       const poolsSet = new Set<string>();
       const walletSupportSet = new Set<string>();
       const featuresSet = new Set<string>();
+      const ironwoodSet = new Set<string>();
 
       allWallets.forEach((wallet) => {
         wallet.devices.forEach((d) => devicesSet.add(d.trim()));
@@ -60,6 +63,7 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
         wallet.pools.forEach((p) => poolsSet.add(p.trim()));
         wallet.walletSupport?.forEach((ws) => walletSupportSet.add(ws.trim()));
         wallet.features.forEach((f) => featuresSet.add(f.trim()));
+        if (wallet.ironwood) ironwoodSet.add(wallet.ironwood.trim());
       });
 
       setFilters({
@@ -72,6 +76,7 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
           Array.from(walletSupportSet).sort((a, b) => a.localeCompare(b)),
         ),
         Features: new Set(Array.from(featuresSet).sort((a, b) => a.localeCompare(b))),
+        Ironwood: new Set(Array.from(ironwoodSet).sort((a, b) => a.localeCompare(b))),
       });
 
       let initialLikes: { [key: string]: number } = {};
@@ -156,6 +161,7 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
       if (category === "Pools") return wallet.pools.includes(value);
       if (category === "Wallet Support") return wallet.walletSupport?.includes(value) ?? false;
       if (category === "Features") return wallet.features.includes(value);
+      if (category === "Ironwood") return wallet.ironwood === value;
       return true;
     }),
   );
@@ -237,6 +243,7 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
                   ]}
                   likes={likes[wallet.title] || 0}
                   syncSpeed={wallet.syncSpeed}
+                  ironwood={wallet.ironwood}
                   onLike={() => handleLike(wallet.title)}
                   onDislike={() => handleDislike(wallet.title)}
                   error={error[wallet.title]}

--- a/src/lib/parseMarkdown.ts
+++ b/src/lib/parseMarkdown.ts
@@ -12,6 +12,7 @@ export function parseMarkdown(md: string) {
     let url = '';
     let imageUrl = '';
     let syncSpeed = '';
+    let ironwood = '';
     const devices: string[] = [];
     const pools: string[] = [];
     const features: string[] = [];
@@ -50,6 +51,10 @@ export function parseMarkdown(md: string) {
         const value = line.split(': ')[1];
         if (value) features.push(...value.split(' | ').map(s => s.trim()));
       }
+      else if (line.startsWith('- Ironwood:')) {
+        const value = line.split(': ')[1];
+        if (value) ironwood = value.trim();
+      }
       else if (line.includes('![syncspeed]')) {
         const match = line.match(/!\[syncspeed\]\((.*?) /);
         if (match) syncSpeed = match[1];
@@ -67,6 +72,7 @@ export function parseMarkdown(md: string) {
       operatingSystem: [...new Set(operatingSystem)],
       walletSupport: [...new Set(walletSupport)],
       syncSpeed,
+      ironwood,
     };
   });
 


### PR DESCRIPTION
Adds the NU6.3 Ironwood readiness indicator to the wallets page.

How it works:

- The parser now reads an optional "- Ironwood:" line from each wallet entry in Wallets.md, the same way it reads Devices, Pools and the other fields.
- Wallets with a status get a small colored badge on their card: green for Ready, amber for In Progress, red for Not Ready. Wallets without a status line show no badge, so nothing changes for entries that haven't been assessed.
- An Ironwood group is also added to the filter sidebar so users can filter to ready wallets. Empty filter groups are skipped, so the group only appears once status data exists.

The status data itself is a companion PR to the zechub repo that adds "- Ironwood:" lines for 14 wallets, based on the community activation checklist and each wallet's own release announcements: https://github.com/ZecHub/zechub/pull/1908

Tested locally against a branch with the status lines: 8 Ready, 4 In Progress and 2 Not Ready badges render, light and dark mode both look right, and the page is unchanged when no status lines are present.

<img width="1706" height="1026" alt="image" src="https://github.com/user-attachments/assets/2571786f-9168-4dd7-98a2-eab2c7d1bc1d" />

