### PR TITLE
Add Zcash Login entry to the Use Cases menu

### DIFF
--- a/dictionaries/ak.json
+++ b/dictionaries/ak.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash Wiase Nyinaa Aban Nnanmusini",
     "Zcash Governance": "Zcash Aban a Wɔde Di Dwuma",
     "Zcash Improvement Proposals": "Zcash Nkɔsoɔ Ho Nsusuiɛ",
+    "Zcash Login": "Zcash Login a wɔde hyɛ mu",
     "Zcash Media": "Zcash Nsɛm ho amanneɛbɔfo",
     "Zcash Organizations": "Zcash Ahyehyɛde ahorow",
     "Zcash Podcasts": "Zcash Podcast ahorow a ɛwɔ hɔ",

--- a/dictionaries/ar.json
+++ b/dictionaries/ar.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "سفراء Zcash العالميون",
     "Zcash Governance": "حوكمة Zcash",
     "Zcash Improvement Proposals": "مقترحات تحسين Zcash",
+    "Zcash Login": "تسجيل الدخول عبر Zcash",
     "Zcash Media": "إعلام Zcash",
     "Zcash Organizations": "منظمات Zcash",
     "Zcash Podcasts": "بودكاست Zcash",

--- a/dictionaries/de.json
+++ b/dictionaries/de.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Globale Zcash-Botschafter",
     "Zcash Governance": "Zcash-Governance",
     "Zcash Improvement Proposals": "Zcash Improvement Proposals",
+    "Zcash Login": "Zcash Login",
     "Zcash Media": "Zcash-Medien",
     "Zcash Organizations": "Zcash-Organisationen",
     "Zcash Podcasts": "Zcash-Podcasts",

--- a/dictionaries/ee.json
+++ b/dictionaries/ee.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash Xexeame Katã ƒe Dutanyanyuigblɔlawo",
     "Zcash Governance": "Zcash Dziɖuɖu",
     "Zcash Improvement Proposals": "Zcash ƒe Ŋgɔyiyi ƒe Aɖaŋuɖoɖowo",
+    "Zcash Login": "Zcash ƒe gege ɖe eme",
     "Zcash Media": "Zcash Nyadzɔdzɔgblɔmɔnuwo",
     "Zcash Organizations": "Zcash Habɔbɔwo",
     "Zcash Podcasts": "Zcash ƒe Podcastwo",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash Global Ambassadors",
     "Zcash Governance": "Zcash Governance",
     "Zcash Improvement Proposals": "Zcash Improvement Proposals",
+    "Zcash Login": "Zcash Login",
     "Zcash Media": "Zcash Media",
     "Zcash Organizations": "Zcash Organizations",
     "Zcash Podcasts": "Zcash Podcasts",

--- a/dictionaries/es.json
+++ b/dictionaries/es.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Embajadores Globales de Zcash",
     "Zcash Governance": "Gobernanza de Zcash",
     "Zcash Improvement Proposals": "Propuestas de mejora de Zcash",
+    "Zcash Login": "Zcash Login",
     "Zcash Media": "Medios de Zcash",
     "Zcash Organizations": "Organizaciones de Zcash",
     "Zcash Podcasts": "Podcasts de Zcash",

--- a/dictionaries/fr.json
+++ b/dictionaries/fr.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Ambassadeurs mondiaux Zcash",
     "Zcash Governance": "Gouvernance Zcash",
     "Zcash Improvement Proposals": "Propositions d'amélioration de Zcash",
+    "Zcash Login": "Connexion Zcash",
     "Zcash Media": "Médias Zcash",
     "Zcash Organizations": "Organisations Zcash",
     "Zcash Podcasts": "Podcasts Zcash",

--- a/dictionaries/hi.json
+++ b/dictionaries/hi.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash वैश्विक राजदूत",
     "Zcash Governance": "Zcash शासन",
     "Zcash Improvement Proposals": "Zcash सुधार प्रस्ताव",
+    "Zcash Login": "Zcash लॉगिन",
     "Zcash Media": "Zcash मीडिया",
     "Zcash Organizations": "Zcash संगठन",
     "Zcash Podcasts": "Zcash पॉडकास्ट",

--- a/dictionaries/ig.json
+++ b/dictionaries/ig.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Ndị nnọchi anya Zcash Global",
     "Zcash Governance": "Ọchịchị Zcash",
     "Zcash Improvement Proposals": "Nkwupụta Mmezi Zcash",
+    "Zcash Login": "Zcash Nbanye",
     "Zcash Media": "Zcash Mgbasa Ozi",
     "Zcash Organizations": "Nzukọ Zcash",
     "Zcash Podcasts": "Zcash Podcasts",

--- a/dictionaries/it.json
+++ b/dictionaries/it.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash Global Ambassadors",
     "Zcash Governance": "Governance di Zcash",
     "Zcash Improvement Proposals": "Zcash Improvement Proposals",
+    "Zcash Login": "Zcash Login",
     "Zcash Media": "Zcash Media",
     "Zcash Organizations": "Organizzazioni Zcash",
     "Zcash Podcasts": "Podcast su Zcash",

--- a/dictionaries/ja.json
+++ b/dictionaries/ja.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash グローバル・アンバサダー",
     "Zcash Governance": "Zcash ガバナンス",
     "Zcash Improvement Proposals": "Zcash 改善提案",
+    "Zcash Login": "Zcash Login",
     "Zcash Media": "Zcash メディア",
     "Zcash Organizations": "Zcash 組織",
     "Zcash Podcasts": "Zcash ポッドキャスト",

--- a/dictionaries/ko.json
+++ b/dictionaries/ko.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash 글로벌 앰배서더",
     "Zcash Governance": "Zcash 거버넌스",
     "Zcash Improvement Proposals": "Zcash 개선 제안",
+    "Zcash Login": "Zcash 로그인",
     "Zcash Media": "Zcash 미디어",
     "Zcash Organizations": "Zcash 조직",
     "Zcash Podcasts": "Zcash 팟캐스트",

--- a/dictionaries/pt.json
+++ b/dictionaries/pt.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Embaixadores globais da Zcash",
     "Zcash Governance": "Governança da Zcash",
     "Zcash Improvement Proposals": "Propostas de melhoria da Zcash",
+    "Zcash Login": "Zcash Login",
     "Zcash Media": "Mídia Zcash",
     "Zcash Organizations": "Organizações Zcash",
     "Zcash Podcasts": "Podcasts Zcash",

--- a/dictionaries/ru.json
+++ b/dictionaries/ru.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash Global Ambassadors",
     "Zcash Governance": "Управление Zcash",
     "Zcash Improvement Proposals": "Предложения по улучшению Zcash",
+    "Zcash Login": "Zcash Login",
     "Zcash Media": "Медиа Zcash",
     "Zcash Organizations": "Организации Zcash",
     "Zcash Podcasts": "Подкасты Zcash",

--- a/dictionaries/sw.json
+++ b/dictionaries/sw.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash Global Mabalozi",
     "Zcash Governance": "Utawala wa Zcash",
     "Zcash Improvement Proposals": "Mapendekezo ya Uboreshaji wa Zcash",
+    "Zcash Login": "Kuingia kwa Zcash",
     "Zcash Media": "Zcash Media",
     "Zcash Organizations": "Mashirika ya Zcash",
     "Zcash Podcasts": "Zcash Podcasts",

--- a/dictionaries/tr.json
+++ b/dictionaries/tr.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash Küresel Elçileri",
     "Zcash Governance": "Zcash Yönetişimi",
     "Zcash Improvement Proposals": "Zcash İyileştirme Önerileri",
+    "Zcash Login": "Zcash Girişi",
     "Zcash Media": "Zcash Medyası",
     "Zcash Organizations": "Zcash Kuruluşları",
     "Zcash Podcasts": "Zcash Podcast'leri",

--- a/dictionaries/uk.json
+++ b/dictionaries/uk.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash Global Ambassadors",
     "Zcash Governance": "Управління Zcash",
     "Zcash Improvement Proposals": "Пропозиції щодо вдосконалення Zcash",
+    "Zcash Login": "Zcash Login",
     "Zcash Media": "Медіа Zcash",
     "Zcash Organizations": "Організації Zcash",
     "Zcash Podcasts": "Подкасти Zcash",

--- a/dictionaries/yo.json
+++ b/dictionaries/yo.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Àwọn Aṣojú Àgbáyé Zcash",
     "Zcash Governance": "Ìdarí Zcash",
     "Zcash Improvement Proposals": "Àwọn Àbá fún Àtúnṣe Zcash",
+    "Zcash Login": "Àkọsílẹ̀ Zcash",
     "Zcash Media": "Ìròyìn Zcash",
     "Zcash Organizations": "Àwọn àjọ Zcash",
     "Zcash Podcasts": "Àwọn ìtòlẹ́sẹẹsẹ Zcash Podcasts",

--- a/dictionaries/zh.json
+++ b/dictionaries/zh.json
@@ -83,6 +83,7 @@
     "Zcash Global Ambassadors": "Zcash 全球大使",
     "Zcash Governance": "Zcash 治理",
     "Zcash Improvement Proposals": "Zcash 改进提案",
+    "Zcash Login": "Zcash 登录",
     "Zcash Media": "Zcash 媒体",
     "Zcash Organizations": "Zcash 组织",
     "Zcash Podcasts": "Zcash 播客",

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -16,7 +16,7 @@ import {
   MdDeveloperMode,
 } from "react-icons/md";
 
-import { Wrench, Map, Gem, BookOpenText } from "lucide-react";
+import { Wrench, Map, Gem, BookOpenText, KeyRound } from "lucide-react";
 import { FcVoicePresentation } from "react-icons/fc";
 import { FaUserAstronaut } from "react-icons/fa";
 
@@ -87,6 +87,11 @@ export const navigations: Array<NavigationItem> = [
 	    name: "Send Money Privately",
 	    path: "/zcash-use-cases/send-money-without-linking-identity",
 	    icon: ArrowUp,
+	  },
+	  {
+	    name: "Zcash Login",
+	    path: "/zcash-use-cases/sign-in-with-zcash",
+	    icon: KeyRound,
 	  },
 	],
       },


### PR DESCRIPTION
Adds the sidebar entry for the new Sign in with Zcash page, so it is reachable from the Use Cases menu rather than only by direct URL.

Content PR it points at: https://github.com/ZecHub/zechub/pull/1913

On the menu label: rather than introducing a new string that would need 18 fresh translations, this reuses the label already used for the Zcash Login hackathon track. Every locale dictionary already has a reviewed value for that term, so each menuLabels entry is copied from that locale's own existing wording. The menu-label coverage gate has no missing entries as a result. Seven locales (it, es, de, pt, ru, ja, uk) keep it as "Zcash Login" because that is what those dictionaries already use for the track, which shows up as the usual advisory rather than a failure.
