### PR TITLE
LeoDex: refresh DEX entry and add to instant swaps

### DIFF
--- a/src/constants/decentralizedExchanges.ts
+++ b/src/constants/decentralizedExchanges.ts
@@ -21,9 +21,9 @@ export const decentralizedExchanges = [
     image: "/content-images/firodex-beta-release-b1958c5adc.webp",
   },
   {
-    title: "LeoDEX",
+    title: "LeoDex",
     description:
-      "A crosschain crypto swapping interface for Maya Protocol, Thorchain, ChainFlip and Rango. BTC, ETH, RUNE, DASH, LTC & More",
+      "Crosschain swaps into and out of ZEC, routed across THORChain, Maya Protocol, Chainflip, NEAR Intents, Relay and Rango. No account, no KYC, and no wallet connection needed on supported routes.",
     url: "https://leodex.io",
     image: "/leodex-logo.png",
   },

--- a/src/constants/dex-listing-config.it.ts
+++ b/src/constants/dex-listing-config.it.ts
@@ -98,4 +98,11 @@ export const dexListingConfigIt = [
     url: 'https://bitcoinvn.io/?deposit=xmr&settle=zec/',
     image: '/Bitcoinvn.png',
   },
+  {
+    title: 'LeoDex',
+    description:
+      'Swap crosschain senza account e senza KYC. Invia BTC, ETH e altro da qualsiasi wallet, exchange o cold storage a un indirizzo di deposito monouso e ricevi ZEC — nessuna connessione del wallet richiesta.',
+    url: 'https://leodex.io/',
+    image: '/leodex-logo.png',
+  },
 ];

--- a/src/constants/dex-listing-config.ts
+++ b/src/constants/dex-listing-config.ts
@@ -98,4 +98,11 @@ export const dexListingConfig = [
     url: 'https://bitcoinvn.io/?deposit=xmr&settle=zec/',
     image: '/Bitcoinvn.png',
   },
+  {
+    title: 'LeoDex',
+    description:
+      'Crosschain swaps with no account and no KYC. Send BTC, ETH and more from any wallet, exchange or cold storage to a one-time deposit address and receive ZEC — no wallet connection required.',
+    url: 'https://leodex.io/',
+    image: '/leodex-logo.png',
+  },
 ];


### PR DESCRIPTION
LeoDex is a crosschain swap aggregator that routes through THORChain, Maya Protocol, Chainflip, NEAR Intents, Relay and Rango. Two changes:

**1. Refresh the existing entry on `/dex`.** The current description doesn't mention ZEC at all, which is the one thing a ZecHub visitor is looking for, and it omits NEAR Intents and Relay (both added since it was written). Also corrects the name casing to "LeoDex". Rango is kept — it's still one of the routes.

**2. Add LeoDex to the instant swaps page** (`dex-listing-config.ts` and the Italian `dex-listing-config.it.ts`). LeoDex fits that page's pattern: swaps run through a one-time deposit address, so there's no account, no KYC and no wallet connection — you send from any wallet, exchange or cold storage and receive ZEC. It reuses the `/leodex-logo.png` already in the repo, so no new assets.

Site: https://leodex.io — LeoDex is also listed on DefiLlama as a DEX Aggregator (https://defillama.com/protocol/leodex) and on the THORChain, Maya Protocol and Chainflip ecosystem pages.

Happy to adjust the wording if you'd prefer it shorter or framed differently.
