### PR TITLE
Fix localized research article rendering

### DIFF
--- a/src/app/[locale]/[...slug]/page.tsx
+++ b/src/app/[locale]/[...slug]/page.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/lib/helpers";
 import { buildAlternates, localesForPath } from "@/lib/localeCoverage";
 import { routing } from "@/i18n/routing";
-import { normalizeMdx } from "@/lib/normalizeMdx";
+import { normalizeMdx, normalizeResearchMdx } from "@/lib/normalizeMdx";
 import { getDictionary } from "@/lib/getDictionary";
 import { Metadata } from "next";
 import React, { Suspense } from "react";
@@ -464,18 +464,7 @@ export default async function Page(props: {
         return `![${alt}](https://raw.githubusercontent.com/ZecHub/zechub/main/${articleDir}/${src})`;
       },
     );
-    processedMarkdown = processedMarkdown.replace(
-      /([^\n])\n?<details>/g,
-      "$1\n\n<details>",
-    );
-    processedMarkdown = processedMarkdown.replace(
-      /<details>\s*<summary>\s*Answer\s*<\/summary>/gi,
-      "\n\n<details>\n<summary>Answer</summary>\n\n",
-    );
-    processedMarkdown = processedMarkdown.replace(
-      /<\/details>([^\n])/g,
-      "</details>\n\n$1",
-    );
+    processedMarkdown = normalizeResearchMdx(processedMarkdown);
   }
 
   const imgUrl = getBanner(slug[0]) || "";

--- a/src/lib/__tests__/normalizeMdx.test.ts
+++ b/src/lib/__tests__/normalizeMdx.test.ts
@@ -1,0 +1,27 @@
+import { normalizeResearchMdx } from "../normalizeMdx";
+
+describe("normalizeResearchMdx", () => {
+  it("puts a localized details summary on its own MDX lines", () => {
+    const source = [
+      "A question.",
+      "",
+      "<details><summary>Antwort</summary>",
+      "",
+      "The answer.",
+      "</details>",
+    ].join("\n");
+
+    expect(normalizeResearchMdx(source)).toBe(
+      "A question.\n\n<details>\n<summary>Antwort</summary>\n\nThe answer.\n\n</details>",
+    );
+  });
+
+  it("preserves localized summary text and attributes", () => {
+    const source =
+      '<details open><summary data-label="localized">Réponse</summary>Text</details>';
+
+    expect(normalizeResearchMdx(source)).toBe(
+      '<details open>\n<summary data-label="localized">Réponse</summary>\n\nText\n\n</details>',
+    );
+  });
+});

--- a/src/lib/normalizeMdx.ts
+++ b/src/lib/normalizeMdx.ts
@@ -1,3 +1,26 @@
 export function normalizeMdx(markdown: string): string {
   return markdown.replace(/\sclass=/g, " className=");
 }
+
+/**
+ * Keep collapsible research answers valid MDX regardless of the language used
+ * inside their summary. A summary such as "Antwort" used to bypass the
+ * English-only formatter in the route and caused the whole article to fail to
+ * compile.
+ */
+export function normalizeResearchMdx(markdown: string): string {
+  return markdown
+    .replace(
+      /(^|[^\n])\n*<details(\s[^>]*)?>\s*<summary(\s[^>]*)?>\s*([\s\S]*?)\s*<\/summary>\s*/gim,
+      (
+        _match,
+        prefix = "",
+        detailsAttributes = "",
+        summaryAttributes = "",
+        summary = "",
+      ) =>
+        `${prefix}${prefix ? "\n\n" : ""}<details${detailsAttributes}>\n<summary${summaryAttributes}>${summary.trim()}</summary>\n\n`,
+    )
+    .replace(/([^\n])\n*<\/details>/gi, "$1\n\n</details>")
+    .replace(/<\/details>([^\n])/gi, "</details>\n\n$1");
+}


### PR DESCRIPTION
## Changes

Normalize research article `<details><summary>…</summary>` markup without assuming an English summary label. This keeps translated articles on their intended localized routes and adds regression coverage for localized text and attributes.

The main cause of this problem is that the renderer only normalized `<summary>Answer</summary>`. A translated label such as German `<summary>Antwort</summary>` reached MDX inline, causing compilation to fail and the browser to show “This page couldn't load.”

## Validation

- `npx jest src/lib/__tests__/normalizeMdx.test.ts --ci --runInBand`
- Serialized the reported German article and all 18 available translated copies of the article with the updated normalizer.
