### PR TITLE
docs(i18n): specify the first-use gloss, and name the list CI actually enforces

### DIFF
--- a/docs/translation-protected-terms.md
+++ b/docs/translation-protected-terms.md
@@ -8,8 +8,8 @@ The goal is to keep wiki translations accurate and consistent. Some terms are pr
 
 - Do not translate protected brand, wallet, protocol, or community program names.
 - Keep the original capitalization unless a page already uses a known variant.
-- When a localized explanation is useful, add it around the term instead of replacing the term.
-- During translation review, compare translated pages against `src/constants/protectedTranslationTerms.ts`.
+- When a localized explanation is useful, add it around the term instead of replacing the term. See [First-Use Gloss](#first-use-gloss) for the form to use.
+- During translation review, check against **both** lists described in [Source of Truth](#source-of-truth). The categorized list in this repo is the easier one to read, but the content repo's `translation/protected-terms.json` is the one CI enforces, and it contains terms this one does not.
 - Future UI work can use this list to wrap generated labels with `translate="no"` or `className="notranslate"`.
 
 ## What Should Be Protected
@@ -45,12 +45,49 @@ Avoid:
 Chiamate dell'arboricoltore
 ```
 
-## Source of Truth
+## First-Use Gloss
 
-The canonical list lives in:
+A protected term must appear verbatim, but that does not mean the reader is left guessing. Some protected terms are **compound technical terms**, where the English words state the meaning — `Unified Address` and `Viewing Key` are the clearest cases, along with the other key and address forms. Understanding them is part of what the page teaches.
 
-```txt
-src/constants/protectedTranslationTerms.ts
+For those, keep the term and add a short localized gloss in parentheses **on first use in the page**, then use the term alone afterwards:
+
+```md
+La Viewing Key (chiave di visualizzazione) consente di visualizzare i dettagli
+delle proprie transazioni schermate senza poter spendere i fondi. Condividi la
+Viewing Key solo con chi deve verificare le tue transazioni.
 ```
 
-If a new wallet, protocol feature, organization, or community program is added to the wiki, add it to the protected term list in the same pull request when appropriate.
+- **Term first, gloss second.** `Viewing Key (chiave di visualizzazione)`, not the reverse. The English term is what the reader meets again in wallets, block explorers, ZIPs and the forum, so it is the string worth anchoring; the gloss teaches the concept once.
+- **First use only.** Repeating the gloss at every mention is noise.
+- **Keep it short** — a word or brief phrase, not a definition. The page defines the concept anyway.
+- **Use the language's established term.** If translators in that language already have a word for the concept, use it rather than coining one.
+- **Never gloss a codename or an acronym.** Many protected terms are ordinary English words borrowed as labels, where the literal meaning is irrelevant and a gloss actively misleads: `Sapling`, `Blossom`, `Heartwood`, `Canopy`, `Sprout`, `Overwinter`, `Orchard`, `Halo`, `Pallas`, `Vesta`, `Zebra`. `Sapling (alberello)` tells the reader something untrue about a network upgrade. The same goes for acronyms — `ZIP`, `ZCAP`, `NU6` — and for brand, wallet, organization, service and community names such as `Zashi`, `ZecHub` or `Arborist Calls`.
+- **Using the categorized list**: within `addressing`, gloss **every expanded address or key compound** — that is `Unified Address`, `Viewing Key`, `Unified Viewing Key`, `Full Viewing Key`, `Incoming Viewing Key`, `Outgoing Viewing Key`, `Spending Key`, `Diversified Address` and `TEX Address` — and leave the **short label forms** bare: `UA`, `UAs`, `t-address`, `z-address`, `u-address`. Do not gloss `protocol`, `cryptography`, `network`, `software`, `brand`, `wallet`, `organization`, `service` or `community`. In `governance`, the acronyms take no gloss while a compound like `Dev Fund` may take one. When a term does not obviously fit, ask whether the English words state the meaning or merely serve as a label — label means no gloss.
+- **Plural forms are not protected, and you should not treat them as protected.** The categorized list carries a few (`Unified Addresses`, `UAs`, `ZIPs`), but pluralizing an English loanword is a language-by-language decision, not an English one. Italian writes *gli Unified Address*, because Italian does not add `-s` to loanwords; Japanese, Korean and Chinese do not inflect plurals at all. So treat the **singular** as the term to preserve, gloss it on its first appearance, and pluralize however your language normally would.
+- **Do not gloss inside** headings, code spans or fences, link text, table cells, image alt text, URLs, or frontmatter. A gloss in a heading changes the page anchor, and a gloss inside a URL or anchor breaks the link outright — the translation-sync tooling compares link destinations between a page and its translation, so that can also cause an automated re-sync to reject the page. Code and frontmatter are not prose. Link text, table cells and image alt text are excluded for readability rather than tooling reasons.
+- For right-to-left languages, follow the pattern already used in the existing Arabic pages so parentheses and Latin text nest correctly.
+
+A parenthetical gloss is for a short equivalent. Explaining a term at length in the surrounding prose — as the `Arborist Calls` example above does — is always fine and is not restricted to compound terms; the rules here govern the short parenthetical form only.
+
+The protected-terms check only asks whether the term is present, so a glossed and an unglossed first mention both pass. This is an editorial convention, not a validation rule.
+
+**Machine translation is not expected to do this.** The sync pipeline re-translates a page block by block and cannot see whether an earlier block already glossed a term, so asking it for "first use only" would produce glosses repeated or missing at random. Glossing is a human-review improvement.
+
+If you hand-edit a machine-translated page, the content repo's `translation/sync-state.json` must record it or the manifest check rejects the change: note what you did in that entry's `tool` field. This applies to **every** edit, not just the first — an `edited: true` flag already set in an earlier pull request is not a standing licence to change the file again without touching the manifest.
+
+Setting `edited: true` additionally protects the page from being overwritten — but be deliberate, because it removes the page from automated sync **permanently**, so later English updates will no longer reach that translation. Reserve it for a page you intend to maintain by hand, and prefer folding a gloss into a fuller human review rather than freezing a whole page for one word.
+
+## Source of Truth
+
+Two lists exist today, and they are not the same:
+
+```txt
+src/constants/protectedTranslationTerms.ts   (this repo — categorized, for UI work and review)
+translation/protected-terms.json             (content repo — the list CI enforces)
+```
+
+The check that gates a pull request reads `preserveVerbatim` from the **content repo's** `translation/protected-terms.json`. If a term is missing there, nothing prevents a translation from localizing it, however carefully the list in this repo is maintained.
+
+The two have drifted. As of 2026-08-14 the categorized list here carries terms the CI list does not enforce — including `Blossom`, `Canopy`, `Brave Wallet`, `Dev Fund` and `BTCPayServer` — while the CI list enforces terms absent here, including `Keystone`, `Ledger`, `Zkool`, `Zingo-CLI` and `eZcash`. Recount before relying on any figure, since both lists change. Reconciling them is an editorial decision rather than a mechanical one: adding a term creates review work in every language whose pages already use it.
+
+If a new wallet, protocol feature, organization, or community program is added to the wiki, add it to both lists as part of the same change. They live in different repositories, so that means a paired pull request in each — and only the content-repo half changes what CI enforces.


### PR DESCRIPTION
## Why

Two gaps in the protected-terms guidance.

**1. The doc already sanctioned a gloss but never said how.** It said *"when a localized explanation is useful, add it around the term instead of replacing the term"* — without saying in what form, where, or how often. Its only worked example used an appositive clause. Translators across 18 languages were left to invent a convention each.

**2. It named the wrong list as canonical.** The Source of Truth section pointed at this repo's `src/constants/protectedTranslationTerms.ts`, but the check that gates a pull request reads `preserveVerbatim` from the **content repo's** `translation/protected-terms.json`. A translator following the docs was reading a list that is 69 terms wider and 12 narrower than the one that actually blocks their PR.

## The rule

For a **compound technical term** — one where the English words state the meaning, like `Unified Address` or `Viewing Key` — keep the term verbatim and add a short localized gloss in parentheses **on first use in the page**, then use the term alone afterwards.

```md
La Viewing Key (chiave di visualizzazione) consente di visualizzare i dettagli
delle proprie transazioni schermate senza poter spendere i fondi.
```

Term first, because the English string is what the reader meets again in wallets, block explorers, ZIPs and the forum; the gloss teaches the concept once.

**The rule turns on codename vs compound, not on whether the English merely looks descriptive.** Most protected terms are ordinary words borrowed as labels — `Sapling`, `Blossom`, `Heartwood`, `Canopy`, `Sprout`, `Overwinter`, `Orchard`, `Halo`, `Pallas`, `Vesta`, `Zebra` — where the literal meaning is irrelevant and a gloss actively misleads. `Sapling (alberello)` tells an Italian reader that a network upgrade is a small tree: grammatically fine, semantically false.

Mapped onto the categories the categorized list already carries: gloss `addressing` (the expanded compounds, not the short label forms `UA`/`UAs`/`t-address`/`z-address`/`u-address`); leave `protocol`, `cryptography`, `network`, `software`, `brand`, `wallet`, `organization`, `service` and `community` bare; in `governance` the acronyms take no gloss while a compound like `Dev Fund` may.

**Plural forms are explicitly excluded.** The categorized list carries a few (`Unified Addresses`, `UAs`, `ZIPs`), but pluralizing an English loanword is a language-by-language decision. Italian writes *gli Unified Address* because Italian does not add `-s` to loanwords; Japanese, Korean and Chinese do not inflect plurals at all. Measured across the corpus, 70% of the pages that "lack" `Unified Addresses` already carry the protected singular — they simply pluralized correctly for their language. So the doc tells translators to treat the singular as the term and pluralize naturally.

Also documented: keep it short, prefer the language's established term, don't gloss inside headings, code, link text, tables, alt text, URLs or frontmatter, and follow the existing Arabic pages for RTL nesting. The check only tests presence, so **this is editorial style, not a gate** — stated explicitly so nobody reads it as one.

**Machine translation is not expected to do this.** The sync pipeline re-translates block by block and cannot know whether an earlier block already glossed a term, so demanding "first use only" would scatter glosses at random. It's a human-review improvement.

## Scope

Measured against the corpus: **37 of 719 English pages (5%)** contain a glossable term in prose, so at most 666 translated pages could ever gain one, and 62 gloss insertions per locale. It's opt-in review, not a sweep — a translator glosses when they're already in a page.

## Second change

The Source of Truth section now names both lists, identifies the CI-enforced one, and records that they have drifted in both directions — terms categorized here that CI does not enforce (`Blossom`, `Canopy`, `Brave Wallet`, `Dev Fund`, `BTCPayServer`) and terms CI enforces that are absent here (`Keystone`, `Ledger`, `Zkool`, `Zingo-CLI`, `eZcash`). Reconciling them is an editorial decision, since adding a term creates review work in every language already using it, so the divergence is documented rather than resolved.

## Review

Reviewed by two independent adversarial passes, both of which blocked earlier revisions on real defects:

- an earlier draft used `Turnstile` as its flagship example — a term on **neither** list, so it would have taught volunteers to preserve something nothing enforces;
- the first category mapping told translators to gloss `protocol` and `network` terms "where the English is descriptive", which pointed straight at `Sapling (alberello)` and contradicted the doc's own never-gloss example of `Zebra`;
- the hand-edit advice recommended `edited: true` without mentioning that it removes a page from automated sync permanently;
- and one bullet still pointed reviewers at the wrong list, two sections above the fix.

All are corrected. Both reviewers returned SHIP on the current revision, and every term named in the doc was checked to exist on at least one list, with the two worked examples verified present in the CI-enforced JSON.

## Related

Companion PR in the content repo protects `Full Viewing Key` and `Incoming Viewing Key`, so two more of the compounds this doc calls glossable are actually enforced. It also records why the plurals are deliberately **not** being added, with the measurements behind that call.

## Unrelated observation

The `glossaryOnly` key in the content repo's terms file (`token`, `chain`, `cross-chain`, `faucet`, `mining`, `miner`) is never read — the checker uses only `preserveVerbatim`. Someone intended a second, softer category, which is exactly where words like `shielded` and `zero` belong, but nothing implements it, so a term added there today is silently unenforced. Flagged rather than fixed, since deciding what it should mean is a maintainer call.
