### PR TITLE
Correct the ZIP 317 transaction fee calculator

### DIFF
--- a/src/components/visualizer/BuildShieldedTransaction/BuildShieldedTransactionContent.tsx
+++ b/src/components/visualizer/BuildShieldedTransaction/BuildShieldedTransactionContent.tsx
@@ -8,10 +8,18 @@ import {
   Activity, Binary, Fingerprint, Link2, Hash,
   ShieldCheck, Layers, FileCode2, Network, ChevronDown, Info,
 } from "lucide-react";
+import {
+  GRACE_ACTIONS,
+  MARGINAL_FEE_ZATOSHIS,
+  type Pool,
+  conventionalFee,
+  logicalActions,
+  simpleTransfer,
+} from "@/lib/zip317";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-export type Pool = "transparent" | "sapling" | "orchard";
+export type { Pool };
 
 export interface StageConfig {
   id: string;
@@ -118,19 +126,6 @@ export const POOL_META: Record<Pool, {
     desc: "Maximum privacy via Halo2 proofs. No trusted setup.",
   },
 };
-
-// ─── ZIP 317 fee calculation ──────────────────────────────────────────────────
-
-export function calculateZip317Fee(
-  transparentInputs = 0,
-  transparentOutputs = 0,
-  shieldedActions = 1
-): number {
-  const baseFee = 10000;
-  const marginalFee = 10000;
-  const logicalActions = 1 + transparentInputs + transparentOutputs + shieldedActions;
-  return baseFee + marginalFee * Math.max(0, logicalActions - 1);
-}
 
 // ─── Live ZEC price hook ──────────────────────────────────────────────────────
 
@@ -1335,12 +1330,19 @@ export const BuilderStage = () => {
   const gradeColor = score >= 90 ? "#34d399" : score >= 70 ? "#fbbf24" : score >= 40 ? "#f97316" : "#f87171";
   const strokeColor = gradeColor;
 
-  const feeZat = calculateZip317Fee(
-    fromPool === "transparent" ? 1 : 0,
-    toPool === "transparent" ? 1 : 0,
-    toPool !== "transparent" ? 1 : 0
-  );
+  // ZIP 317 prices a transaction by its logical actions, one contribution per
+  // pool, so the pools chosen above decide the fee.
+  const tx = simpleTransfer(fromPool, toPool);
+  const actions = logicalActions(tx);
+  const feeZat = conventionalFee(tx);
   const feeZEC = (feeZat / 100_000_000).toFixed(8);
+  const actionsByPool = [
+    actions.transparent > 0 && `${actions.transparent} transparent`,
+    actions.sapling > 0 && `${actions.sapling} Sapling`,
+    actions.orchard > 0 && `${actions.orchard} Orchard`,
+  ]
+    .filter(Boolean)
+    .join(" + ");
   const change = Math.max(0, amount - parseFloat(feeZEC)).toFixed(5);
   const usd = zecPrice ? (amount * zecPrice).toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : null;
 
@@ -1491,7 +1493,7 @@ export const BuilderStage = () => {
             {/* Stats */}
             <div className="grid grid-cols-2 gap-2">
               {[
-                { label: "Est. Fee", value: feeZEC + " ZEC", sub: "ZIP 317" },
+                { label: "Est. Fee", value: feeZEC + " ZEC", sub: `ZIP 317 · ${actions.billed} actions` },
                 { label: "Change",   value: change + " ZEC", sub: "returned to sender" },
                 { label: "From pool",value: POOL_META[fromPool].label, sub: POOL_META[fromPool].tag },
                 { label: "To pool",  value: POOL_META[toPool].label,   sub: POOL_META[toPool].tag },
@@ -1505,6 +1507,12 @@ export const BuilderStage = () => {
                 </motion.div>
               ))}
             </div>
+
+            <p className="text-[9px] text-zinc-600 leading-relaxed">
+              Fee = {MARGINAL_FEE_ZATOSHIS.toLocaleString("en-US")} zats ×
+              max({GRACE_ACTIONS} grace actions, {actions.total} logical actions)
+              {actionsByPool && <> · {actionsByPool}</>}
+            </p>
 
             <motion.button onClick={() => setShowModal(true)}
               whileHover={{ scale: 1.02, boxShadow: "0 0 30px rgba(52,211,153,0.22)" }}

--- a/src/lib/__tests__/zip317.test.ts
+++ b/src/lib/__tests__/zip317.test.ts
@@ -1,0 +1,115 @@
+import {
+  GRACE_ACTIONS,
+  MARGINAL_FEE_ZATOSHIS,
+  P2PKH_STANDARD_INPUT_SIZE,
+  P2PKH_STANDARD_OUTPUT_SIZE,
+  type Pool,
+  conventionalFee,
+  logicalActions,
+  simpleTransfer,
+} from "../zip317";
+
+const POOLS: Pool[] = ["transparent", "sapling", "orchard"];
+
+describe("ZIP 317 parameters", () => {
+  it("matches the values published in the spec", () => {
+    expect(MARGINAL_FEE_ZATOSHIS).toBe(5000);
+    expect(GRACE_ACTIONS).toBe(2);
+    expect(P2PKH_STANDARD_INPUT_SIZE).toBe(150);
+    expect(P2PKH_STANDARD_OUTPUT_SIZE).toBe(34);
+  });
+});
+
+describe("logicalActions", () => {
+  it("counts transparent inputs and outputs as the larger of the two sides", () => {
+    const actions = logicalActions({
+      txInTotalSize: 10 * 150,
+      txOutTotalSize: 2 * 34,
+    });
+
+    expect(actions.transparent).toBe(10);
+    expect(actions.total).toBe(10);
+  });
+
+  it("rounds a partial standard size up to a whole action", () => {
+    expect(logicalActions({ txOutTotalSize: 35 }).transparent).toBe(2);
+    expect(logicalActions({ txInTotalSize: 151 }).transparent).toBe(2);
+  });
+
+  it("charges two actions per Sprout JoinSplit", () => {
+    expect(logicalActions({ nJoinSplit: 3 }).sprout).toBe(6);
+  });
+
+  it("pairs Sapling spends with outputs instead of adding them", () => {
+    expect(logicalActions({ nSpendsSapling: 2, nOutputsSapling: 1 }).sapling).toBe(2);
+    expect(logicalActions({ nSpendsSapling: 2, nOutputsSapling: 5 }).sapling).toBe(5);
+  });
+
+  it("takes Orchard and Ironwood action counts directly", () => {
+    const actions = logicalActions({ nActionsOrchard: 4, nActionsIronwood: 3 });
+
+    expect(actions.orchard).toBe(4);
+    expect(actions.ironwood).toBe(3);
+  });
+
+  it("sums one contribution per pool", () => {
+    const actions = logicalActions({
+      txInTotalSize: 150,
+      nSpendsSapling: 1,
+      nOutputsSapling: 2,
+      nActionsOrchard: 2,
+    });
+
+    expect(actions.total).toBe(1 + 2 + 2);
+  });
+
+  it("bills the grace actions when a transaction is smaller than them", () => {
+    expect(logicalActions({}).billed).toBe(2);
+    expect(logicalActions({ nActionsOrchard: 1 }).billed).toBe(2);
+    expect(logicalActions({ nActionsOrchard: 3 }).billed).toBe(3);
+  });
+});
+
+describe("conventionalFee", () => {
+  it("is marginal_fee times max(grace_actions, logical_actions)", () => {
+    expect(conventionalFee({})).toBe(10_000);
+    expect(conventionalFee({ nActionsOrchard: 2 })).toBe(10_000);
+    expect(conventionalFee({ nActionsOrchard: 10 })).toBe(50_000);
+  });
+
+  it("prices a ten input sweep into one output", () => {
+    expect(
+      conventionalFee({ txInTotalSize: 10 * 150, txOutTotalSize: 34 }),
+    ).toBe(50_000);
+  });
+
+  it("ignores negative and fractional counts", () => {
+    expect(conventionalFee({ nActionsOrchard: -5 })).toBe(10_000);
+    expect(conventionalFee({ nSpendsSapling: 2.9 })).toBe(10_000);
+  });
+});
+
+describe("simpleTransfer", () => {
+  it.each(POOLS.flatMap((from) => POOLS.map((to) => [from, to] as const)))(
+    "costs the 0.0001 ZEC minimum from %s to %s",
+    (from, to) => {
+      const actions = logicalActions(simpleTransfer(from, to));
+
+      expect(actions.total).toBe(2);
+      expect(conventionalFee(simpleTransfer(from, to))).toBe(10_000);
+    },
+  );
+
+  it("keeps the recipient and the change in the pools they belong to", () => {
+    expect(simpleTransfer("transparent", "orchard")).toMatchObject({
+      txInTotalSize: 150,
+      txOutTotalSize: 34,
+      nActionsOrchard: 1,
+    });
+
+    expect(simpleTransfer("sapling", "sapling")).toMatchObject({
+      nSpendsSapling: 1,
+      nOutputsSapling: 2,
+    });
+  });
+});

--- a/src/lib/zip317.ts
+++ b/src/lib/zip317.ts
@@ -1,0 +1,106 @@
+/**
+ * ZIP 317 conventional transaction fee.
+ *
+ * Spec: https://zips.z.cash/zip-0317
+ *
+ *   conventional_fee = marginal_fee * max(grace_actions, logical_actions)
+ *
+ * The part that is easy to get wrong is logical_actions. It is not the number
+ * of components a transaction touches: each pool contributes separately, and
+ * inside a pool spends and outputs pair up so only the larger side counts.
+ * Transparent inputs and outputs are measured in bytes and divided by the
+ * standard P2PKH sizes below.
+ */
+
+export const MARGINAL_FEE_ZATOSHIS = 5000;
+export const GRACE_ACTIONS = 2;
+export const P2PKH_STANDARD_INPUT_SIZE = 150;
+export const P2PKH_STANDARD_OUTPUT_SIZE = 34;
+
+export type Pool = "transparent" | "sapling" | "orchard";
+
+/** Field names follow ZIP 317 so this can be read side by side with the spec. */
+export interface Zip317Transaction {
+  /** Total size in bytes of the tx_in field. */
+  txInTotalSize?: number;
+  /** Total size in bytes of the tx_out field. */
+  txOutTotalSize?: number;
+  /** Number of Sprout JoinSplits. */
+  nJoinSplit?: number;
+  nSpendsSapling?: number;
+  nOutputsSapling?: number;
+  nActionsOrchard?: number;
+  /** Revision 1 (NU6.3). Ironwood Actions have the same shape as Orchard ones. */
+  nActionsIronwood?: number;
+}
+
+export interface LogicalActions {
+  transparent: number;
+  sprout: number;
+  sapling: number;
+  orchard: number;
+  ironwood: number;
+  /** Sum of the per-pool contributions. */
+  total: number;
+  /** What the fee is actually charged on: max(grace_actions, total). */
+  billed: number;
+}
+
+const whole = (value: number | undefined) => Math.max(0, Math.floor(value ?? 0));
+
+/** Bytes contributed by a number of standard P2PKH inputs. */
+export const p2pkhInputsSize = (inputs: number) =>
+  whole(inputs) * P2PKH_STANDARD_INPUT_SIZE;
+
+/** Bytes contributed by a number of standard P2PKH outputs. */
+export const p2pkhOutputsSize = (outputs: number) =>
+  whole(outputs) * P2PKH_STANDARD_OUTPUT_SIZE;
+
+export function logicalActions(tx: Zip317Transaction): LogicalActions {
+  const transparent = Math.max(
+    Math.ceil(whole(tx.txInTotalSize) / P2PKH_STANDARD_INPUT_SIZE),
+    Math.ceil(whole(tx.txOutTotalSize) / P2PKH_STANDARD_OUTPUT_SIZE),
+  );
+  const sprout = 2 * whole(tx.nJoinSplit);
+  const sapling = Math.max(whole(tx.nSpendsSapling), whole(tx.nOutputsSapling));
+  const orchard = whole(tx.nActionsOrchard);
+  const ironwood = whole(tx.nActionsIronwood);
+
+  const total = transparent + sprout + sapling + orchard + ironwood;
+
+  return {
+    transparent,
+    sprout,
+    sapling,
+    orchard,
+    ironwood,
+    total,
+    billed: Math.max(GRACE_ACTIONS, total),
+  };
+}
+
+/** The conventional fee in zatoshis. */
+export function conventionalFee(tx: Zip317Transaction): number {
+  return logicalActions(tx).billed * MARGINAL_FEE_ZATOSHIS;
+}
+
+/**
+ * The transaction shape behind a one-note transfer: a single note or UTXO is
+ * spent in `from`, the recipient is paid in `to`, and change goes back to the
+ * sender's own pool.
+ */
+export function simpleTransfer(from: Pool, to: Pool): Zip317Transaction {
+  const spendsIn = (pool: Pool) => (from === pool ? 1 : 0);
+  // The recipient's output, plus the change output returned to the sender.
+  const outputsIn = (pool: Pool) => (to === pool ? 1 : 0) + (from === pool ? 1 : 0);
+
+  return {
+    txInTotalSize: p2pkhInputsSize(spendsIn("transparent")),
+    txOutTotalSize: p2pkhOutputsSize(outputsIn("transparent")),
+    nSpendsSapling: spendsIn("sapling"),
+    nOutputsSapling: outputsIn("sapling"),
+    // An Orchard Action carries one spend and one output, so a bundle needs as
+    // many Actions as the busier side, padded with dummies.
+    nActionsOrchard: Math.max(spendsIn("orchard"), outputsIn("orchard")),
+  };
+}


### PR DESCRIPTION
Fixes the ZIP 317 fee calculation in the Build a Shielded Transaction visualizer.

### The bug

`calculateZip317Fee` in `BuildShieldedTransactionContent.tsx` was:

```ts
const baseFee = 10000;
const marginalFee = 10000;
const logicalActions = 1 + transparentInputs + transparentOutputs + shieldedActions;
return baseFee + marginalFee * Math.max(0, logicalActions - 1);
```

Three things are off against [ZIP 317](https://zips.z.cash/zip-0317):

1. There is no base fee in the spec, and `marginal_fee` is 5,000 zats, not 10,000.
2. The formula is `marginal_fee × max(grace_actions, logical_actions)` with `grace_actions = 2`, not a base plus a per extra action charge.
3. Logical actions are not a flat sum of everything a transaction touches. Each pool contributes separately, and inside a pool spends and outputs pair up so only the busier side counts.

The visible symptom: an Orchard to Orchard send was quoted at 0.0002 ZEC, while the Output Description stage of the same visualizer already shows the correct 0.0001 ZEC on the change note.

### The fix

Moved the calculation into `src/lib/zip317.ts`, following the spec directly:

```
conventional_fee = marginal_fee * max(grace_actions, logical_actions)
```

Logical actions are now built one contribution per pool, with the ZIP's own field names so the code can be read next to the spec:

| Pool | Contribution |
| --- | --- |
| Transparent | `max(ceil(tx_in_total_size / 150), ceil(tx_out_total_size / 34))` |
| Sprout | `2 × nJoinSplit` |
| Sapling | `max(nSpendsSapling, nOutputsSapling)` |
| Orchard | `nActionsOrchard` |
| Ironwood | `nActionsIronwood` (revision 1) |

`simpleTransfer(from, to)` builds the shape the visualizer actually models: one note or UTXO spent in the sender's pool, the recipient paid in the target pool, change back to the sender. Every pool pair comes out at 2 logical actions, so the builder now quotes 0.0001 ZEC across the board, which is what a wallet charges for a simple send and is the point ZIP 317 is making.

The fee panel also shows the formula it just applied, e.g.

> Fee = 5,000 zats × max(2 grace actions, 2 logical actions) · 1 transparent + 1 Sapling

so the number is no longer unexplained.

### Testing

- `src/lib/__tests__/zip317.test.ts`, 21 cases covering the spec parameters, each pool contribution, the grace floor, byte rounding, and all nine pool pairs. These live under `src/lib` so the existing `lib-tests` job runs them.
- `yarn jest src/lib` passes, 6 suites / 57 tests.
- `yarn build` clean, `tsc --noEmit` clean, no new eslint findings.
- Walked all nine From/To pool combinations in Chromium against `yarn build && yarn start` and checked the fee, the action count and the breakdown line each time.
