### PR TITLE
Fix six dead routes in navigation and search

### DIFF
--- a/src/components/SiteLinks/SiteLinks.tsx
+++ b/src/components/SiteLinks/SiteLinks.tsx
@@ -28,7 +28,7 @@ const SiteLinks: React.FC = () => {
               <Link href="/dao">Dao</Link>
             </li>
             <li className="elementor-sitemap-item elementor-sitemap-item-page page_item page-item-5668">
-              <Link href="/brand/">Brand</Link>
+              <Link href="/zcash-organizations/brand">Brand</Link>
             </li>
             <li className="elementor-sitemap-item elementor-sitemap-item-page page_item page-item-5470">
               <Link href="/wallets">Wallets</Link>
@@ -68,7 +68,7 @@ const SiteLinks: React.FC = () => {
               </Link>
             </li>
             <li className="elementor-sitemap-item elementor-sitemap-item-question page_item page-item-5989">
-              <Link href="/guides/akash-network">Akash Network</Link>
+              <Link href="/guides/akash-network-zebra">Akash Network</Link>
             </li>
             <li className="elementor-sitemap-item elementor-sitemap-item-question page_item page-item-5987">
               <Link href="/guides/visualizing-zcash-addresses">

--- a/src/constants/searcher.ts
+++ b/src/constants/searcher.ts
@@ -126,7 +126,7 @@ export const searcher: Searcher[] = [
   {
     name: "Akash Network",
     desc: "Guide to using Zcash on the Akash decentralized cloud computing network.",
-    url: "/guides/akash-network",
+    url: "/guides/akash-network-zebra",
   },
   {
     name: "Avalanche RedBridge",
@@ -491,19 +491,9 @@ export const searcher: Searcher[] = [
 
   // ZFAV Club
   {
-    name: "ZFAV Club Background",
-    desc: "Supported by The Zcash Foundation this ambitious grassroots project aims...",
-    url: "/zfav-club/av-club-background",
-  },
-  {
     name: "Guides for Creators",
     desc: "Guides for creators...",
     url: "/zfav-club/guides-for-creators",
-  },
-  {
-    name: "Youtube Channel",
-    desc: "Youtube Channel...",
-    url: "/zfav-club/youtube-channel",
   },
 
   // Glossary & FAQs
@@ -549,7 +539,7 @@ export const searcher: Searcher[] = [
   {
     name: "Brand",
     desc: "ZecHub brand assets, logos, and guidelines.",
-    url: "/brand",
+    url: "/zcash-organizations/brand",
   },
   { name: "Dashboard", desc: "Check the charts for ZEC", url: "/dashboard" },
   { name: "DAO", desc: "List of ZecHub DAO members", url: "/dao" },
@@ -592,7 +582,7 @@ export const searcher: Searcher[] = [
   {
     name: "Tutorials",
     desc: "How to buy ZEC in Gemini",
-    url: "/tutorials/buy-zec-in-gemini",
+    url: "/tutorials/exchanges",
   },
   {
     name: "Full Node Tutorials",
@@ -602,7 +592,7 @@ export const searcher: Searcher[] = [
   {
     name: "Shielding ZEC",
     desc: "This video was created to show users how to shield their ZEC.",
-    url: "/tutorials/shielding-zec",
+    url: "/tutorials/using-zcash",
   },
   {
     name: "Wallet Tutorials",

--- a/src/constants/siteLinks.ts
+++ b/src/constants/siteLinks.ts
@@ -36,7 +36,7 @@ export const SITE_LINKS: SiteLinkSection[] = [
       { label: "Contribute", href: "/contribute/help-build-zechub" },
       { label: "DAO", href: "/dao" },
       { label: "Developers", href: "/developers" },
-      { label: "Brand", href: "/brand/" },
+      { label: "Brand", href: "/zcash-organizations/brand" },
       { label: "Wallets", href: "/wallets" },
       { label: "Sitemap", href: "/sitemap/" },
       {
@@ -111,7 +111,7 @@ export const SITE_LINKS: SiteLinkSection[] = [
         href: "https://free2z.com/ZecHub/zpage/zcash-101-zebra-lightwalletd-sync-journal-on-raspberry-pi-5",
         target: "_blank",
       },
-      { label: "Akash Network", href: "/guides/akash-network" },
+      { label: "Akash Network", href: "/guides/akash-network-zebra" },
       { label: "Avalanche RedBridge", href: "/guides/avalanche-redbridge" },
       { label: "Zkool Multisig", href: "/guides/zkool-multisig" },
       { label: "Ywallet FROST Demo", href: "/guides/ywallet-frost-demo" },


### PR DESCRIPTION
Ten references across `searcher.ts`, `siteLinks.ts` and the unreferenced
`SiteLinks` component point at routes with no backing page.

Routes were resolved through the app's own resolver — `transformUri()` in
`src/lib/helpers.ts`, as used by `getDynamicRoute()` — rather than by pattern
matching, so app-served routes and the casing rules are handled the way the app
handles them.

| Route | Problem | Now |
|---|---|---|
| `/brand` | no `site/Brand.md` | `/zcash-organizations/brand` (app route) |
| `/guides/akash-network` | page split into `-zebra` / `-zcashd` | `/guides/akash-network-zebra` |
| `/tutorials/buy-zec-in-gemini` | no such page | `/tutorials/exchanges` |
| `/tutorials/shielding-zec` | no such page | `/tutorials/using-zcash` |
| `/zfav-club/av-club-background` | no such page | entry removed |
| `/zfav-club/youtube-channel` | no such page | entry removed |

**Akash:** the guide was split into Zebra and zcashd variants. zcashd reached
its End-of-Support halt at block 3,417,100 on 2026-07-18, so nav and search now
point at the Zebra page.

**Gemini / Shielding:** both destinations are video entries on pages that
already exist — `site/tutorials/Exchanges.md` line 7 and
`site/tutorials/Using_Zcash.md` line 31.

**ZFAV Club:** no `AV_Club_Background` or `Youtube_Channel` page exists in the
content repo; `site/ZFAV_Club/` holds only `Guides_for_Creators`. Both search
entries are removed rather than retargeted, since there is nothing to point them
at. The existing external YouTube link in `siteLinks.ts` is untouched.

**Correction to the bounty description.** It listed a seventh route,
`/zcash-organizations/ZODL`, as dead. It is not. `transformUri` title-cases each
segment, so the uppercase form survives intact and resolves to
`site/Zcash_Organizations/ZODL.md`. The lowercase form is the one that misses the
deterministic path, since `ZODL` is absent from the `uppercaseWords` list in
`helpers.ts:327`; it is rescued only by the fuzzy directory match in `page.tsx`.
`src/app/sitemap.ts:63` already documents that both forms resolve to identical
content. All three ZODL references are left unchanged.

**`SiteLinks` component.** `src/components/SiteLinks/SiteLinks.tsx` carried the
same two bad hrefs and is fixed here for consistency, but it is imported nowhere
in `src/` and nothing renders it. Happy to remove it in a follow-up if that is
wanted — it seemed out of scope for a route fix.

## Verification

- `npx tsc --noEmit` reports 17 errors on `upstream/main` and 17 on this branch —
  identical counts. All are pre-existing `TS2307` image-import errors in
  `Brand.tsx`, `Row.tsx`, `ZcashProjects.tsx` and `visualizer/zcash-wallet/types.ts`.
  None are in the files changed here.
- `npx eslint` on the three changed files: clean.
- `yarn install --frozen-lockfile` succeeds; `yarn.lock` unmodified.
- `yarn lint` could not be used — the repo's `lint` script still calls `next lint`,
  which was removed in Next 16 and now reads `lint` as a directory argument.
  Pre-existing and unrelated to this change; ESLint was run directly instead.
- [BROWSER CHECK — write what you actually loaded and what each returned, or
  delete this bullet entirely.]