### PR TITLE
Add Project Tachyon diagrams to content-images

### DIFF
--- a/public/content-images/tachyon-oblivious-sync.svg
+++ b/public/content-images/tachyon-oblivious-sync.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 330" width="760" height="330" role="img" aria-label="With Tachyon the sender passes payment details to the recipient out of band, and the wallet uses oblivious synchronization to retrieve only its own data instead of scanning the whole chain">
+  <rect width="760" height="330" rx="12" fill="#f7f8fa"/>
+  <text x="24" y="36" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="17" font-weight="700" fill="#14161a">With Tachyon: the details travel with the payment request</text>
+  <text x="24" y="58" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" fill="#5b6472">The chain stops being the delivery channel for secrets, so the wallet no longer has to search it.</text>
+
+  <rect x="24" y="82" width="200" height="66" rx="8" fill="#ffffff" stroke="#c9d0d9"/>
+  <text x="124" y="108" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#14161a" text-anchor="middle">Sender</text>
+  <text x="124" y="130" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="12" fill="#5b6472" text-anchor="middle">builds the payment</text>
+
+  <rect x="280" y="82" width="200" height="66" rx="8" fill="#e8f2ed" stroke="#2f7d5d"/>
+  <text x="380" y="104" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#1f5741" text-anchor="middle">Out-of-band</text>
+  <text x="380" y="124" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="12" fill="#1f5741" text-anchor="middle">payment request or URI</text>
+  <text x="380" y="141" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="11" fill="#3d7d63" text-anchor="middle">carries what you need to spend</text>
+
+  <rect x="536" y="82" width="200" height="66" rx="8" fill="#ffffff" stroke="#c9d0d9"/>
+  <text x="636" y="108" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#14161a" text-anchor="middle">Your wallet</text>
+  <text x="636" y="130" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="12" fill="#5b6472" text-anchor="middle">already knows the payment</text>
+
+  <g stroke="#2f7d5d" stroke-width="2" fill="none" marker-end="url(#ar)">
+    <path d="M228 115 H274"/><path d="M484 115 H530"/>
+  </g>
+  <defs><marker id="ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto"><path d="M0 0 L10 5 L0 10 z" fill="#2f7d5d"/></marker></defs>
+
+  <rect x="24" y="176" width="712" height="60" rx="8" fill="#eceff3"/>
+  <text x="44" y="200" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#14161a">Oblivious synchronization</text>
+  <text x="44" y="222" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" fill="#3d4552">The wallet still needs current chain state to spend. It fetches only what it needs, without revealing which parts it asked for.</text>
+
+  <rect x="24" y="252" width="712" height="56" rx="8" fill="#eceff3"/>
+  <text x="44" y="276" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#14161a">The trade</text>
+  <text x="44" y="296" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" fill="#3d4552">Syncing stops growing with the chain. In exchange, wallets must keep payment data safe themselves, because the chain no longer holds a copy.</text>
+</svg>

--- a/public/content-images/tachyon-scanning-today.svg
+++ b/public/content-images/tachyon-scanning-today.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 760 300" width="760" height="300" role="img" aria-label="Today a Zcash wallet downloads every shielded transaction and trial-decrypts each one to find the few that belong to it">
+  <rect width="760" height="300" rx="12" fill="#f7f8fa"/>
+  <text x="24" y="36" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="17" font-weight="700" fill="#14161a">Today: the wallet tests every transaction</text>
+  <text x="24" y="58" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" fill="#5b6472">The chain cannot tell your wallet which payments are yours, so the wallet checks all of them.</text>
+  <text x="24" y="94" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="12" font-weight="600" fill="#5b6472">SHIELDED TRANSACTIONS ON THE CHAIN</text>
+  <g>
+    <rect x="24"  y="106" width="52" height="42" rx="6" fill="#dfe3e8"/><rect x="84"  y="106" width="52" height="42" rx="6" fill="#dfe3e8"/>
+    <rect x="144" y="106" width="52" height="42" rx="6" fill="#2f7d5d"/><rect x="204" y="106" width="52" height="42" rx="6" fill="#dfe3e8"/>
+    <rect x="264" y="106" width="52" height="42" rx="6" fill="#dfe3e8"/><rect x="324" y="106" width="52" height="42" rx="6" fill="#dfe3e8"/>
+    <rect x="384" y="106" width="52" height="42" rx="6" fill="#dfe3e8"/><rect x="444" y="106" width="52" height="42" rx="6" fill="#2f7d5d"/>
+    <rect x="504" y="106" width="52" height="42" rx="6" fill="#dfe3e8"/><rect x="564" y="106" width="52" height="42" rx="6" fill="#dfe3e8"/>
+    <rect x="624" y="106" width="52" height="42" rx="6" fill="#dfe3e8"/><rect x="684" y="106" width="52" height="42" rx="6" fill="#dfe3e8"/>
+  </g>
+  <g font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="11" fill="#8b95a3" text-anchor="middle">
+    <text x="50" y="166">try</text><text x="110" y="166">try</text><text x="230" y="166">try</text><text x="290" y="166">try</text>
+    <text x="350" y="166">try</text><text x="410" y="166">try</text><text x="530" y="166">try</text><text x="590" y="166">try</text>
+    <text x="650" y="166">try</text><text x="710" y="166">try</text>
+  </g>
+  <text x="170" y="166" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#2f7d5d" text-anchor="middle">yours</text>
+  <text x="470" y="166" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="11" font-weight="700" fill="#2f7d5d" text-anchor="middle">yours</text>
+  <rect x="24" y="196" width="712" height="76" rx="8" fill="#eceff3"/>
+  <text x="44" y="222" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" font-weight="600" fill="#14161a">Trial decryption</text>
+  <text x="44" y="244" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" fill="#3d4552">The wallet attempts to decrypt each transaction in turn. Almost every attempt fails. Two succeed.</text>
+  <text x="44" y="264" font-family="Segoe UI, Helvetica, Arial, sans-serif" font-size="13" fill="#3d4552">The work grows with the size of the whole chain, not with the number of payments you received.</text>
+</svg>


### PR DESCRIPTION
MERGE FIRST

Two original SVG diagrams for the Project Tachyon wiki page, which is submitted
separately to ZecHub/zechub as `site/Zcash_Tech/Project_Tachyon.md`.

- `tachyon-scanning-today.svg` — how a wallet finds its own payments today, trial
  decrypting transaction after transaction with almost every attempt failing
- `tachyon-oblivious-sync.svg` — the model Tachyon proposes, with payment details
  passed out of band and oblivious synchronization replacing the scan

Both are hand-authored SVG rather than exported bitmaps, so they stay sharp at any
size and remain diffable. Each carries a descriptive `aria-label`, and the page
references them with long-form alt text.

Paired with the page PR in ZecHub/zechub. The page references these at
`/content-images/`, so merging this one first avoids a window where the diagrams 404.
