### PR TITLE
Show a breadcrumb above every wiki article

### DIFF
--- a/src/app/[locale]/[...slug]/page.tsx
+++ b/src/app/[locale]/[...slug]/page.tsx
@@ -20,6 +20,7 @@ import {
   extractArticleMeta,
   jsonLdScript,
 } from "@/lib/helpers";
+import { buildBreadcrumbs } from "@/lib/breadcrumbs";
 import { buildAlternates, localesForPath } from "@/lib/localeCoverage";
 import { routing } from "@/i18n/routing";
 import { normalizeMdx, normalizeResearchMdx } from "@/lib/normalizeMdx";
@@ -481,6 +482,15 @@ export default async function Page(props: {
     : "";
   const localeUrlPrefix = locale && locale !== "en" ? `/${locale}` : "";
   const canonicalWikiUrl = `https://zechub.wiki${localeUrlPrefix}/${slug.join("/")}`;
+  // One trail for both the visible breadcrumb and the BreadcrumbList below, so
+  // what a reader sees and what a crawler reads cannot drift apart. Research
+  // articles keep the trail their own layout already renders.
+  const breadcrumbTrail = buildBreadcrumbs({
+    slug,
+    titles: menuTitles,
+    enTitles: enMenuTitles,
+    menuLabels: dict?.menuLabels ?? {},
+  });
 
   if (!markdown) {
     // A null `markdown` has two very different causes. Section landing pages
@@ -501,6 +511,7 @@ export default async function Page(props: {
         }
         roots={roots}
         heroImage={{ src: imgUrl, darkSrc: imgUrlDark }}
+        breadcrumbs={breadcrumbTrail}
       >
         <div className="px-6 py-12 text-center">
           <h1 className="text-5xl font-bold mb-6 capitalize">
@@ -553,20 +564,12 @@ export default async function Page(props: {
   // that don't merge across <script> blocks still resolve author/publisher) and
   // a BreadcrumbList derived from the slug segments. Consumed by classic search
   // and AI answer engines; rendered server-side (SSR route).
-  const breadcrumbItems = [
-    {
-      "@type": "ListItem" as const,
-      position: 1,
-      name: "Home",
-      item: `https://zechub.wiki${localeUrlPrefix}`,
-    },
-    ...slug.map((_, i) => ({
-      "@type": "ListItem" as const,
-      position: i + 2,
-      name: slugToTitle(slug[i]),
-      item: `https://zechub.wiki${localeUrlPrefix}/${slug.slice(0, i + 1).join("/")}`,
-    })),
-  ];
+  const breadcrumbItems = breadcrumbTrail.map((crumb, i) => ({
+    "@type": "ListItem" as const,
+    position: i + 1,
+    name: crumb.label,
+    item: `https://zechub.wiki${localeUrlPrefix}${crumb.href === "/" ? "" : crumb.href}`,
+  }));
   const jsonLd = {
     "@context": "https://schema.org",
     "@graph": [
@@ -610,6 +613,7 @@ export default async function Page(props: {
         }
         roots={roots}
         {...(heroImage ? { heroImage } : {})}
+        breadcrumbs={isResearchArticle ? undefined : breadcrumbTrail}
         layoutVariant={isResearchArticle ? "research" : "default"}
         researchMeta={
           isResearchArticle

--- a/src/components/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs.tsx
@@ -1,0 +1,55 @@
+import { Link } from "@/i18n/navigation";
+import type { BreadcrumbItem } from "@/lib/breadcrumbs";
+
+type BreadcrumbsProps = {
+  items: BreadcrumbItem[];
+  /** Accessible name for the nav landmark. */
+  label?: string;
+};
+
+/**
+ * The trail above an article. Markup and classes match the one the research
+ * layout already renders, so both variants look the same; the last item is the
+ * current page and is not a link.
+ */
+export default function Breadcrumbs({
+  items,
+  label = "Breadcrumb",
+}: BreadcrumbsProps) {
+  if (items.length < 2) return null;
+
+  return (
+    <nav
+      className="mb-6 text-xs font-medium text-muted-foreground"
+      aria-label={label}
+    >
+      <ol className="flex flex-wrap items-center gap-1.5">
+        {items.map((item, i) => {
+          const isCurrent = i === items.length - 1;
+
+          return (
+            <li key={item.href} className="flex items-center gap-1.5">
+              {i > 0 && (
+                <span aria-hidden className="text-muted-foreground/80">
+                  /
+                </span>
+              )}
+              {isCurrent ? (
+                <span aria-current="page" className="text-foreground/90">
+                  {item.label}
+                </span>
+              ) : (
+                <Link
+                  href={item.href}
+                  className="transition-colors hover:text-foreground"
+                >
+                  {item.label}
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/src/components/MdxContainer.tsx
+++ b/src/components/MdxContainer.tsx
@@ -1,6 +1,8 @@
 import Image from "next/image";
 import { Link } from "@/i18n/navigation";
+import Breadcrumbs from "@/components/Breadcrumbs";
 import ResearchArticleAside from "@/components/Research/ResearchArticleAside";
+import type { BreadcrumbItem } from "@/lib/breadcrumbs";
 
 type MdxContainerProps = {
   roots: any;
@@ -13,6 +15,11 @@ type MdxContainerProps = {
     width?: number;
     height?: number;
   };
+  /**
+   * Trail shown above the article, so a reader landing on a deep page can see
+   * where it sits. Research pages render their own inside the variant below.
+   */
+  breadcrumbs?: BreadcrumbItem[];
   /** BitMEX-style editorial layout for research article pages. */
   layoutVariant?: "default" | "research";
   researchMeta?: {
@@ -35,6 +42,7 @@ export default async function MdxContainer({
   roots = [],
   hasSideMenu = false,
   children,
+  breadcrumbs,
   layoutVariant = "default",
   researchMeta,
 }: MdxContainerProps) {
@@ -132,6 +140,7 @@ export default async function MdxContainer({
               hasSideMenu ? "xl:border-l" : ""
             }`}
           >
+            {breadcrumbs ? <Breadcrumbs items={breadcrumbs} /> : null}
             {children}
           </section>
         )}

--- a/src/lib/__tests__/breadcrumbs.test.ts
+++ b/src/lib/__tests__/breadcrumbs.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Unit tests for the article breadcrumb trail.
+ *
+ * breadcrumbs.ts imports helpers.ts, which imports getRootCached from
+ * authAndFetch (for firstFileForFolders) and so pulls in next/cache. Mock that
+ * module, the same way transformUri.test.ts does, to keep this a pure test.
+ */
+
+jest.mock("../authAndFetch", () => ({
+  getRootCached: jest.fn(async () => []),
+}));
+
+import { buildBreadcrumbs, manifestKey } from "../breadcrumbs";
+
+const titles = {
+  "Using_Zcash/Payment_Processors.md": "Zcash Payment Processors",
+  "Glossary_and_FAQs/FAQ.md": "Frequently Asked Questions",
+};
+
+describe("manifestKey", () => {
+  it("maps a slug to its content path without the site/ prefix", () => {
+    expect(manifestKey(["using-zcash", "payment-processors"])).toBe(
+      "Using_Zcash/Payment_Processors.md",
+    );
+  });
+
+  it("maps a section segment to the folder's own key", () => {
+    expect(manifestKey(["using-zcash"])).toBe("Using_Zcash.md");
+  });
+
+  it("keeps the hand-mapped contribute path", () => {
+    expect(manifestKey(["contribute", "community-infrastructure"])).toBe(
+      "contribute/Community_Infrastructure.md",
+    );
+  });
+});
+
+describe("buildBreadcrumbs", () => {
+  it("puts the wiki root first, linked to /", () => {
+    const [root] = buildBreadcrumbs({ slug: ["using-zcash"] });
+    expect(root).toEqual({ label: "Wiki", href: "/" });
+  });
+
+  it("builds the trail the bounty asks for", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["using-zcash", "payment-processors"],
+    });
+    expect(trail.map((c) => c.label)).toEqual([
+      "Wiki",
+      "Using Zcash",
+      "Payment Processors",
+    ]);
+  });
+
+  it("links each crumb to its own section, locale-less", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["zcash-tech", "what-a-block-explorer-can-see"],
+    });
+    expect(trail.map((c) => c.href)).toEqual([
+      "/",
+      "/zcash-tech",
+      "/zcash-tech/what-a-block-explorer-can-see",
+    ]);
+  });
+
+  it("ends on the page itself", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["start-here", "who-can-see-your-zcash-payment"],
+    });
+    expect(trail[trail.length - 1].href).toBe(
+      "/start-here/who-can-see-your-zcash-payment",
+    );
+  });
+
+  it("prefers the menu-titles manifest over the filename", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["using-zcash", "payment-processors"],
+      titles,
+    });
+    expect(trail[2].label).toBe("Zcash Payment Processors");
+  });
+
+  it("falls back to the English manifest when the locale has no entry", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["using-zcash", "payment-processors"],
+      titles: {},
+      enTitles: titles,
+    });
+    expect(trail[2].label).toBe("Zcash Payment Processors");
+  });
+
+  it("prefers the localized manifest over the English one", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["using-zcash", "payment-processors"],
+      titles: { "Using_Zcash/Payment_Processors.md": "Procesadores de pago" },
+      enTitles: titles,
+    });
+    expect(trail[2].label).toBe("Procesadores de pago");
+  });
+
+  it("translates section segments through menuLabels", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["using-zcash", "payment-processors"],
+      menuLabels: { "Using Zcash": "Usar Zcash" },
+    });
+    expect(trail[1].label).toBe("Usar Zcash");
+  });
+
+  it("keeps the curated Glossary name", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["glossary-and-faqs", "faq"],
+      titles,
+    });
+    expect(trail.map((c) => c.label)).toEqual([
+      "Wiki",
+      "Glossary & FAQ's",
+      "Frequently Asked Questions",
+    ]);
+  });
+
+  it("matches manifest keys whose file is cased differently on disk", () => {
+    // The manifest calls it NU5.md; the slug transform produces Nu5.md.
+    const trail = buildBreadcrumbs({
+      slug: ["zcash-tech", "nu5"],
+      titles: { "Zcash_Tech/NU5.md": "Network Upgrade 5" },
+    });
+    expect(trail[2].label).toBe("Network Upgrade 5");
+  });
+
+  it("still prefers an exact key over a differently cased one", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["zcash-tech", "nu5"],
+      titles: {
+        "Zcash_Tech/NU5.md": "wrong case",
+        "Zcash_Tech/Nu5.md": "exact match",
+      },
+    });
+    expect(trail[2].label).toBe("exact match");
+  });
+
+  it("uses the filename when nothing is translated", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["privacy-tools", "secure-messengers"],
+    });
+    expect(trail[2].label).toBe("Secure Messengers");
+  });
+
+  it("handles a deep path one crumb per segment", () => {
+    const trail = buildBreadcrumbs({
+      slug: ["research", "zcash-foundations-series", "part-one"],
+    });
+    expect(trail).toHaveLength(4);
+    expect(trail[3].href).toBe("/research/zcash-foundations-series/part-one");
+  });
+
+  it("accepts an overridden root label", () => {
+    const trail = buildBreadcrumbs({ slug: ["guides"], rootLabel: "ZecHub" });
+    expect(trail[0].label).toBe("ZecHub");
+  });
+
+  it("returns just the root for an empty slug", () => {
+    expect(buildBreadcrumbs({ slug: [] })).toEqual([
+      { label: "Wiki", href: "/" },
+    ]);
+  });
+
+  it("ignores blank segments", () => {
+    const trail = buildBreadcrumbs({ slug: ["using-zcash", "", "  "] });
+    expect(trail.map((c) => c.href)).toEqual(["/", "/using-zcash"]);
+  });
+});

--- a/src/lib/breadcrumbs.ts
+++ b/src/lib/breadcrumbs.ts
@@ -1,0 +1,96 @@
+import { getName, resolveContentPath } from "./helpers";
+
+/**
+ * Breadcrumb trail for a wiki page, derived from its URL slug.
+ *
+ * Research articles already render a hand-written "Wiki / Research / ..." trail
+ * inside MdxContainer. Every other article got its content and side menu with
+ * nothing saying where the page sits, which is a problem when someone arrives
+ * on a deep page straight from search or a shared link.
+ *
+ * Labels come from the same source the side menu uses, so the trail and the
+ * menu never disagree: the content repo's translated menu-titles manifest,
+ * then the English manifest, then the curated `menuLabels` dictionary, then the
+ * filename. Only leaf pages exist in the manifest (it is keyed by ".md" path),
+ * so section segments fall through to `menuLabels`, which is where their
+ * translations live anyway.
+ */
+
+export interface BreadcrumbItem {
+  /** Display text, already localized. */
+  label: string;
+  /** Locale-less wiki path, e.g. "/using-zcash". The last item is the current page. */
+  href: string;
+}
+
+export interface BuildBreadcrumbsInput {
+  /** URL slug segments, e.g. ["using-zcash", "payment-processors"]. */
+  slug: string[];
+  /** Menu-titles manifest for the active locale, keyed "Using_Zcash/Payment_Processors.md". */
+  titles?: Record<string, string>;
+  /** English manifest, used when the active locale has no entry. */
+  enTitles?: Record<string, string>;
+  /** Dictionary `menuLabels`, keyed by the English display name. */
+  menuLabels?: Record<string, string>;
+  /** Label for the first crumb. Matches the research layout's wording by default. */
+  rootLabel?: string;
+}
+
+/** The manifest key for a slug: its content path minus the "site/" prefix. */
+export const manifestKey = (slug: string[]): string =>
+  resolveContentPath(slug).replace(/^\/?site\//, "");
+
+/**
+ * Look a key up ignoring case.
+ *
+ * The manifest is keyed by the file's real name on disk ("NU5.md",
+ * "What_a_Block_Explorer_Can_See.md") while the slug transform re-capitalises
+ * every word ("Nu5.md", "What_A_Block_Explorer_Can_See.md"). page.tsx settles
+ * the same difference by fuzzy-matching a fetched directory listing; this is
+ * the pure equivalent. Without it 37 of the 205 English entries miss and those
+ * pages show a filename instead of their real title.
+ */
+const findTitle = (
+  manifest: Record<string, string>,
+  key: string,
+): string | undefined => {
+  const exact = manifest[key];
+  if (exact !== undefined) return exact;
+
+  const wanted = key.toLowerCase();
+  for (const name of Object.keys(manifest)) {
+    if (name.toLowerCase() === wanted) return manifest[name];
+  }
+  return undefined;
+};
+
+export function buildBreadcrumbs({
+  slug,
+  titles = {},
+  enTitles = {},
+  menuLabels = {},
+  rootLabel = "Wiki",
+}: BuildBreadcrumbsInput): BreadcrumbItem[] {
+  const segments = slug.filter((segment) => segment.trim() !== "");
+  const trail: BreadcrumbItem[] = [{ label: rootLabel, href: "/" }];
+
+  segments.forEach((_, i) => {
+    const upTo = segments.slice(0, i + 1);
+    const key = manifestKey(upTo);
+    // Same call shape the side menu uses for its own labels: getName wants the
+    // hyphenated slug with a leading capital, not the underscored content path.
+    const segment = upTo[upTo.length - 1];
+    const fallback = getName(segment.charAt(0).toUpperCase() + segment.slice(1));
+
+    trail.push({
+      label:
+        findTitle(titles, key) ??
+        findTitle(enTitles, key) ??
+        menuLabels[fallback] ??
+        fallback,
+      href: `/${upTo.join("/")}`,
+    });
+  });
+
+  return trail;
+}


### PR DESCRIPTION
Research pages already show a "Wiki / Research / ..." trail. Start Here, Using Zcash, Zcash Tech, Privacy Tools and the guides don't, so someone arriving on a deep page from search or a shared link can read the article without knowing what section it's in.

`buildBreadcrumbs` turns the slug into a trail and labels it the way SideMenu does: translated menu-titles manifest, then English, then `menuLabels`, then the filename. The last crumb ends up matching the side menu, so `/using-zcash/payment-processors` reads "Wiki / Using Zcash / Zcash Payment Processors". Keys are matched case-insensitively because the manifest has `NU5.md` and `What_a_Block_Explorer_Can_See.md` while `transformUri` produces `Nu5.md` and `What_A_Block_Explorer_Can_See.md`. Without that, 37 of the 205 English entries miss; with it 204 of 205 resolve, and the one left over is a research article that renders its own trail anyway.

The JSON-LD `BreadcrumbList` is built from the same array now so the visible trail and the structured data can't drift. That changes the first item's name from "Home" to "Wiki" and gives the rest real titles instead of slug-cased text. Happy to drop that part and leave the old JSON-LD if you'd rather.

No dictionary changes, root label hardcoded "Wiki" like the research layout does, research pages untouched. `npx jest src/lib --ci` gives 6 suites / 55 tests, 19 of them new.
