### PR TITLE
Search and suggested pages on the 404 page

### DIFF
--- a/src/app/[locale]/[...slug]/not-found.tsx
+++ b/src/app/[locale]/[...slug]/not-found.tsx
@@ -1,22 +1,46 @@
+import { getLocale } from "next-intl/server";
+
 import { Link } from "@/i18n/navigation";
+import NotFoundSearch from "@/components/NotFoundSearch";
+import { searcher } from "@/constants/searcher";
+import { getMenuTitlesCached } from "@/lib/authAndFetch";
+import { buildSearchIndex } from "@/lib/searchIndex";
 
 // Rendered when the [...slug] catch-all calls notFound() for a URL that
 // resolves to neither an article nor a browsable section (see page.tsx).
 // Kept intentionally minimal and on-brand; the surrounding chrome (nav,
 // providers) comes from the [locale] layout.
-export default function NotFound() {
+export default async function NotFound() {
+  // Same index the nav search box gets in layout.tsx, from the same cached
+  // manifests, so a dead URL is answered without a second data source. A
+  // manifest fetch that fails returns {}, and buildSearchIndex falls back to
+  // the curated static entries, so the page still searches.
+  const locale = await getLocale().catch(() => "en");
+  const [englishTitles, localizedTitles] = await Promise.all([
+    getMenuTitlesCached("en"),
+    locale === "en" ? Promise.resolve({}) : getMenuTitlesCached(locale),
+  ]);
+  const searchItems = buildSearchIndex({
+    englishTitles,
+    localizedTitles,
+    staticEntries: searcher,
+  });
+
   return (
     <main className="container m-auto flex min-h-[60vh] flex-col items-center justify-center px-6 py-16 text-center">
       <p className="text-7xl font-bold text-brand">404</p>
       <h1 className="mt-4 text-3xl font-bold sm:text-4xl">Page not found</h1>
       <p className="mt-4 max-w-md text-lg text-muted-foreground">
         We couldn&apos;t find the page you were looking for. It may have been
-        moved, renamed, or never existed. Try browsing the wiki from the
-        homepage.
+        moved, renamed, or never existed. Search the wiki below, or try one of
+        the pages we think you meant.
       </p>
+
+      <NotFoundSearch searchItems={searchItems} />
+
       <Link
         href="/"
-        className="mt-8 inline-flex items-center rounded-lg bg-brand px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-hover"
+        className="mt-10 inline-flex items-center rounded-lg bg-brand px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-brand-hover"
       >
         ← Back to home
       </Link>

--- a/src/app/[locale]/[...slug]/page.tsx
+++ b/src/app/[locale]/[...slug]/page.tsx
@@ -2,6 +2,7 @@ import MdxContainer from "@/components/MdxContainer";
 import ResearchIndexGrid from "@/components/Research/ResearchIndexGrid";
 import SideMenu from "@/components/SideMenu/SideMenu";
 import { Link } from "@/i18n/navigation";
+import { isKnownContentPath } from "@/lib/contentPaths";
 import {
   getFileContentCached,
   getLocalizedFileContentCached,
@@ -172,6 +173,9 @@ export default async function Page(props: {
     getMenuTitlesCached(locale),
     getMenuTitlesCached("en"),
   ]);
+  // English keys are the full content-file list; a localized manifest only
+  // covers what has been translated, so it would under-report folders.
+  const manifestPaths = Object.keys(enMenuTitles ?? {});
 
   const url = getDynamicRoute(slug);
   const urlRoot = `/site/${slug[0]}`;
@@ -490,7 +494,13 @@ export default async function Page(props: {
     // article NOR a folder to browse — `getRootCached` caught its 404 and
     // returned []. Only that second case is a real 404; return notFound() so
     // the app stops serving HTTP 200 empty placeholder pages for dead URLs.
-    if (roots.length === 0) {
+    //
+    // A dead article URL under a real section (e.g. /zcash-tech/light-wallet-
+    // node) passes the `roots` check, because `roots` lists the section rather
+    // than the article. isKnownContentPath tells the two apart from the
+    // manifest: anything naming a real file or folder keeps the behaviour it
+    // has today, and only a URL the manifest has never heard of becomes a 404.
+    if (roots.length === 0 || !isKnownContentPath(slug, manifestPaths)) {
       return notFound();
     }
     return (

--- a/src/components/NotFoundSearch.tsx
+++ b/src/components/NotFoundSearch.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import {
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from "react";
+import { MdArrowForward as ArrowIcon } from "react-icons/md";
+import { Link, usePathname, useRouter } from "@/i18n/navigation";
+import { routing } from "@/i18n/routing";
+import { useLanguage } from "@/context/LanguageContext";
+import { pathSectionLabel, searchWiki } from "@/lib/wikiSearch";
+import { suggestPages } from "@/lib/notFoundSuggestions";
+import { HighlightMatch } from "./SearchBar/HighlightMatch";
+import { SearchInput } from "./SearchBar/SearchInput";
+import { Icon } from "./UI/Icon";
+import type { Searcher } from "@/types";
+
+const RESULT_LIMIT = 6;
+
+type NotFoundSearchProps = {
+  /** The same index the nav search box uses, built in not-found.tsx. */
+  searchItems: readonly Searcher[];
+};
+
+/**
+ * Search box and recovery suggestions for the 404 page.
+ *
+ * The reader arrives here having already typed or followed something close to
+ * a real page, so the failed path is the best query available. It is read from
+ * usePathname rather than passed in, because Next does not give not-found.tsx
+ * the URL that missed. Typing takes over from there and searches the whole
+ * wiki, which is the same call the nav search box makes.
+ */
+export default function NotFoundSearch({ searchItems }: NotFoundSearchProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { t } = useLanguage();
+  const [query, setQuery] = useState("");
+
+  const trimmedQuery = query.trim();
+  const hasQuery = trimmedQuery.length > 0;
+
+  const suggestions = useMemo(
+    () => suggestPages(searchItems, pathname, { locales: routing.locales }),
+    [searchItems, pathname],
+  );
+
+  const results = useMemo(
+    () =>
+      hasQuery ? searchWiki(searchItems, trimmedQuery).slice(0, RESULT_LIMIT) : [],
+    [hasQuery, searchItems, trimmedQuery],
+  );
+
+  const list = hasQuery ? results : suggestions;
+  const heading = hasQuery
+    ? t.common?.searchResultsLabel || "Results"
+    : t.common?.searchSuggested || "Suggested pages";
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+  };
+
+  // Enter opens the top hit. SearchInput swallows form submission, so the key
+  // has to be handled here or it would do nothing at all.
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    const first = list[0];
+    if (first) router.push(first.url);
+  };
+
+  return (
+    <div className="mt-10 w-full max-w-xl text-left">
+      <SearchInput
+        id="not-found-search-input"
+        hintId="not-found-search-hint"
+        searchInput={query}
+        handleSearch={handleChange}
+        onKeyDown={handleKeyDown}
+      />
+      <p
+        id="not-found-search-hint"
+        className="mt-2 text-xs text-slate-500 dark:text-slate-400"
+      >
+        {t.common?.searchHint ||
+          "Search by page title, topic, or path. Use arrow keys to choose, Enter to open."}
+      </p>
+
+      {list.length > 0 ? (
+        <>
+          <h2 className="mt-8 text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+            {heading}
+          </h2>
+          <ul className="mt-3 flex flex-col gap-1.5">
+            {list.map((item) => {
+              const section = pathSectionLabel(item.url);
+
+              return (
+                <li key={item.url}>
+                  <Link
+                    href={item.url}
+                    className="block rounded-xl outline-none transition focus-visible:ring-2 focus-visible:ring-blue-500"
+                  >
+                    <div className="flex items-start gap-3 rounded-xl border border-transparent bg-white px-3 py-3 text-left transition hover:border-slate-200 dark:bg-slate-900 dark:hover:border-slate-600 dark:hover:bg-slate-800/90 sm:px-4">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                          <span className="text-base font-semibold text-slate-900 dark:text-white">
+                            <HighlightMatch
+                              text={item.name}
+                              query={trimmedQuery}
+                            />
+                          </span>
+                          {section ? (
+                            <span className="inline-flex shrink-0 rounded-md bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-slate-600 dark:bg-slate-800 dark:text-slate-400">
+                              {section}
+                            </span>
+                          ) : null}
+                        </div>
+                        <p className="mt-1 line-clamp-2 text-sm text-slate-600 dark:text-slate-400">
+                          <HighlightMatch
+                            text={item.desc}
+                            query={trimmedQuery}
+                          />
+                        </p>
+                      </div>
+                      <Icon
+                        className="mt-1 h-4 w-4 shrink-0 text-slate-400 dark:text-slate-500"
+                        icon={ArrowIcon}
+                        aria-hidden
+                      />
+                    </div>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </>
+      ) : null}
+
+      {hasQuery && results.length === 0 ? (
+        <div className="mt-8 text-sm">
+          <p className="font-medium text-slate-700 dark:text-slate-200">
+            {t.common?.searchNoResults || "No matching pages"}
+          </p>
+          <p className="mt-1 text-slate-500 dark:text-slate-400">
+            {t.common?.searchTryDifferent ||
+              "Try shorter queries, synonyms, or different words."}
+          </p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/SearchBar/SearchInput.tsx
+++ b/src/components/SearchBar/SearchInput.tsx
@@ -5,7 +5,17 @@ import { forwardRef } from "react";
 import { useLanguage } from "@/context/LanguageContext";
 
 export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
-  ({ searchInput, handleSearch, onKeyDown, id = "wiki-search-input" }, ref) => {
+  (
+    {
+      searchInput,
+      handleSearch,
+      onKeyDown,
+      id = "wiki-search-input",
+      hintId = "wiki-search-hint",
+      placeholder,
+    },
+    ref,
+  ) => {
     const { t } = useLanguage();
     const label = t.common?.search || "Search";
 
@@ -35,8 +45,8 @@ export const SearchInput = forwardRef<HTMLInputElement, SearchInputProps>(
             onChange={handleSearch}
             onKeyDown={onKeyDown}
             className="block w-full rounded-xl border border-slate-200 bg-slate-50 py-3 pl-10 pr-3 text-sm text-slate-900 shadow-sm outline-none ring-0 transition placeholder:text-slate-400 focus:border-blue-500 focus:bg-white focus:ring-2 focus:ring-blue-500/20 dark:border-slate-600 dark:bg-slate-800/80 dark:text-white dark:placeholder:text-slate-500 dark:focus:border-blue-400 dark:focus:bg-slate-900 dark:focus:ring-blue-400/25"
-            placeholder={`${label}…`}
-            aria-describedby="wiki-search-hint"
+            placeholder={placeholder ?? `${label}…`}
+            aria-describedby={hintId}
           />
         </div>
       </form>

--- a/src/lib/__tests__/contentPaths.test.ts
+++ b/src/lib/__tests__/contentPaths.test.ts
@@ -1,0 +1,89 @@
+import { isKnownContentPath } from "../contentPaths";
+
+// A slice of the real manifest: flat section files plus the nested folders.
+const keys = [
+  "Zcash_Tech/Lightwallet_Nodes.md",
+  "Zcash_Tech/NU5.md",
+  "Using_Zcash/Payment_Processors.md",
+  "Using_Zcash/Spend_Zcash/Top_10_Places_to_spend_ZEC.md",
+  "guides/frostdemo/ywallet-frost-demo.md",
+  "ZFAV_Club/Guides_for_Creators/AI_tools.md",
+  "Research/zcash-foundations-series/article-0/article-0-shielded-transaction.md",
+];
+
+describe("isKnownContentPath", () => {
+  it("treats a section root as browsable", () => {
+    expect(isKnownContentPath(["zcash-tech"], keys)).toBe(true);
+    expect(isKnownContentPath(["anything-at-all"], keys)).toBe(true);
+  });
+
+  it("recognises a nested folder that files live under", () => {
+    expect(isKnownContentPath(["guides", "frostdemo"], keys)).toBe(true);
+    expect(isKnownContentPath(["using-zcash", "spend-zcash"], keys)).toBe(true);
+    expect(isKnownContentPath(["zfav-club", "guides-for-creators"], keys)).toBe(
+      true,
+    );
+  });
+
+  it("recognises a folder several levels down", () => {
+    expect(
+      isKnownContentPath(["research", "zcash-foundations-series"], keys),
+    ).toBe(true);
+    expect(
+      isKnownContentPath(
+        ["research", "zcash-foundations-series", "article-0"],
+        keys,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a dead article URL under a real section", () => {
+    // The bounty's example: a near-miss for Zcash_Tech/Lightwallet_Nodes.md.
+    expect(isKnownContentPath(["zcash-tech", "light-wallet-node"], keys)).toBe(
+      false,
+    );
+    expect(
+      isKnownContentPath(["using-zcash", "payment-procesors"], keys),
+    ).toBe(false);
+  });
+
+  it("recognises the article files themselves", () => {
+    // Several nested articles land on the browse view today for unrelated
+    // reasons. They are real content, so they keep that behaviour rather than
+    // becoming 404s.
+    expect(isKnownContentPath(["zcash-tech", "lightwallet-nodes"], keys)).toBe(
+      true,
+    );
+    expect(
+      isKnownContentPath(["guides", "frostdemo", "ywallet-frost-demo"], keys),
+    ).toBe(true);
+    expect(
+      isKnownContentPath(
+        ["using-zcash", "spend-zcash", "top-10-places-to-spend-zec"],
+        keys,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a made-up subfolder of a real nested folder", () => {
+    expect(isKnownContentPath(["guides", "frostdemo", "nope"], keys)).toBe(
+      false,
+    );
+    expect(
+      isKnownContentPath(["research", "zcash-foundations-series", "article-9"], keys),
+    ).toBe(false);
+  });
+
+  it("keeps the old behaviour when the manifest is unavailable", () => {
+    // An empty manifest means the fetch failed; 404ing every browse page on a
+    // content-repo outage would be worse than serving the old placeholder.
+    expect(isKnownContentPath(["guides", "frostdemo"], [])).toBe(true);
+    expect(isKnownContentPath(["zcash-tech", "light-wallet-node"], [])).toBe(
+      true,
+    );
+  });
+
+  it("returns false for an empty slug", () => {
+    expect(isKnownContentPath([], keys)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/notFoundSuggestions.test.ts
+++ b/src/lib/__tests__/notFoundSuggestions.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for the 404 page's recovery suggestions.
+ *
+ * The index is built through buildSearchIndex from a small manifest, the same
+ * pipeline the nav search box uses, so the scores these assertions rely on are
+ * the scores production produces.
+ */
+
+import { buildSearchIndex } from "../searchIndex";
+import {
+  MIN_SUGGESTION_SCORE,
+  pathToQuery,
+  suggestPages,
+} from "../notFoundSuggestions";
+
+const englishTitles = {
+  "Zcash_Tech/Lightwallet_Nodes.md": "Zcash Lightwallet Nodes",
+  "Zcash_Tech/NU5.md": "NU5",
+  "Zcash_Tech/NU6.md": "NU6",
+  "Zcash_Tech/NU6_1.md": "NU6.1",
+  "Zcash_Tech/Crosslink_Protocol.md": "Crosslink Protocol",
+  "Using_Zcash/Payment_Processors.md": "Zcash Payment Processors",
+  "Privacy_Tools/GrapheneOS.md": "Graphene OS",
+  "Start_Here/Who_Can_See_Your_Zcash_Payment.md":
+    "Who Can See Your Zcash Payment?",
+};
+
+const index = buildSearchIndex({ englishTitles, staticEntries: [] });
+
+const locales = ["en", "es", "fr"] as const;
+
+describe("pathToQuery", () => {
+  it("turns the last path segment into words", () => {
+    expect(pathToQuery("/zcash-tech/light-wallet-node")).toBe(
+      "light wallet node",
+    );
+  });
+
+  it("treats underscores as word breaks too", () => {
+    expect(pathToQuery("/zcash_tech/light_wallet_node")).toBe(
+      "light wallet node",
+    );
+  });
+
+  it("ignores the section, which only adds noise", () => {
+    expect(pathToQuery("/using-zcash/aaaaaaa")).toBe("aaaaaaa");
+  });
+
+  it("strips a locale prefix when the locales are known", () => {
+    expect(pathToQuery("/es/zcash-tech/light-wallet-node", locales)).toBe(
+      "light wallet node",
+    );
+  });
+
+  it("keeps a first segment that is not a locale", () => {
+    expect(pathToQuery("/guides/light-wallet-node", locales)).toBe(
+      "light wallet node",
+    );
+  });
+
+  it("returns nothing for a path that is only a locale", () => {
+    expect(pathToQuery("/es", locales)).toBe("");
+  });
+
+  it("drops an extension an old bookmark still carries", () => {
+    expect(pathToQuery("/using-zcash/payment-processors.html")).toBe(
+      "payment processors",
+    );
+  });
+
+  it("ignores a trailing slash", () => {
+    expect(pathToQuery("/zcash-tech/nu-5/")).toBe("nu 5");
+  });
+
+  it("drops a query string and hash", () => {
+    expect(pathToQuery("/zcash-tech/nu-5?ref=x#top")).toBe("nu 5");
+  });
+
+  it("decodes a percent-encoded segment", () => {
+    expect(pathToQuery("/zcash-tech/light%20wallet")).toBe("light wallet");
+  });
+
+  it("survives a malformed percent escape", () => {
+    expect(() => pathToQuery("/zcash-tech/%zz")).not.toThrow();
+  });
+
+  it("returns nothing for the root", () => {
+    expect(pathToQuery("/")).toBe("");
+    expect(pathToQuery("")).toBe("");
+  });
+});
+
+describe("suggestPages", () => {
+  it("offers the page the bounty's example URL was reaching for", () => {
+    const [first] = suggestPages(index, "/zcash-tech/light-wallet-node");
+    expect(first).toMatchObject({
+      name: "Zcash Lightwallet Nodes",
+      url: "/zcash-tech/lightwallet-nodes",
+    });
+  });
+
+  it("recovers from a spelling error", () => {
+    const [first] = suggestPages(index, "/using-zcash/payment-procesors");
+    expect(first?.url).toBe("/using-zcash/payment-processors");
+  });
+
+  it("recovers from a shortened or renamed slug", () => {
+    const [first] = suggestPages(index, "/start-here/who-can-see-payment");
+    expect(first?.url).toBe("/start-here/who-can-see-your-zcash-payment");
+  });
+
+  it("works through a locale prefix", () => {
+    const [first] = suggestPages(index, "/es/privacy-tools/graphene", {
+      locales,
+    });
+    expect(first?.url).toBe("/privacy-tools/grapheneos");
+  });
+
+  it("offers nothing for a URL that resembles no page", () => {
+    expect(suggestPages(index, "/qwerty-nonsense")).toEqual([]);
+    expect(suggestPages(index, "/asdfghjkl")).toEqual([]);
+  });
+
+  it("offers nothing for the root or an empty path", () => {
+    expect(suggestPages(index, "/")).toEqual([]);
+    expect(suggestPages(index, "")).toEqual([]);
+  });
+
+  it("withholds a match that does not clear the score floor", () => {
+    // "protokol" scores 399 against Crosslink Protocol, so the same path is
+    // answered or withheld purely on where the floor sits.
+    const path = "/zcash-tech/protokol";
+    expect(suggestPages(index, path, { minScore: 0 })).toHaveLength(1);
+    expect(suggestPages(index, path, { minScore: 500 })).toEqual([]);
+  });
+
+  it("offers nothing at all for a path that matches nothing", () => {
+    expect(suggestPages(index, "/qwerty-nonsense")).toEqual([]);
+    expect(suggestPages(index, "/zcash-tech/asdfghjkl")).toEqual([]);
+  });
+
+  it("honours the limit", () => {
+    const limited = suggestPages(index, "/zcash-tech/payment", {
+      limit: 1,
+      minScore: 0,
+      relativeFloor: 0,
+    });
+    expect(limited).toHaveLength(1);
+  });
+
+  it("drops matches far weaker than the best one", () => {
+    const all = suggestPages(index, "/zcash-tech/nu-5", {
+      relativeFloor: 0,
+      limit: 50,
+    });
+    const trimmed = suggestPages(index, "/zcash-tech/nu-5", {
+      relativeFloor: 0.99,
+      limit: 50,
+    });
+    expect(trimmed.length).toBeLessThan(all.length);
+    expect(trimmed[0]?.url).toBe("/zcash-tech/nu5");
+  });
+
+  it("returns suggestions best first", () => {
+    const results = suggestPages(index, "/zcash-tech/light-wallet-node", {
+      minScore: 0,
+      relativeFloor: 0,
+      limit: 50,
+    });
+    expect(results[0]?.url).toBe("/zcash-tech/lightwallet-nodes");
+  });
+
+  it("keeps the floor inside the calibrated band", () => {
+    // Measured against the live index: noise tops out at "baz" 334, and the
+    // weakest typo worth answering is "glosary" 365. Moving the floor outside
+    // that band starts either suggesting junk or dropping real near-misses.
+    expect(MIN_SUGGESTION_SCORE).toBeGreaterThan(334);
+    expect(MIN_SUGGESTION_SCORE).toBeLessThanOrEqual(365);
+  });
+
+  it("keeps near-miss variants of the same upgrade together", () => {
+    // NU5 668, NU6 570, NU6.1 569 - all worth offering for /nu-5.
+    const urls = suggestPages(index, "/zcash-tech/nu-5").map((i) => i.url);
+    expect(urls).toContain("/zcash-tech/nu5");
+    expect(urls.length).toBeGreaterThan(1);
+  });
+
+  it("returns an empty list for an empty index", () => {
+    expect(suggestPages([], "/zcash-tech/light-wallet-node")).toEqual([]);
+  });
+});

--- a/src/lib/contentPaths.ts
+++ b/src/lib/contentPaths.ts
@@ -1,0 +1,49 @@
+/**
+ * Does a wiki URL name anything the content manifest knows about?
+ *
+ * The catch-all route falls back to a "browse the sidebar" view whenever it
+ * finds no article file. That is right for a section root like /guides, but
+ * wrong for a dead article URL like /zcash-tech/light-wallet-node, which
+ * answers HTTP 200 with an empty placeholder instead of a 404.
+ *
+ * The menu-titles manifest lists every content file, so a URL is known if it
+ * matches a file or any folder above one. That keeps two cases on their
+ * current path: real folders such as /guides/frostdemo, and articles that the
+ * route already fails to render for unrelated reasons (several nested ones
+ * land on the browse view today). Only URLs the manifest has never heard of
+ * are treated as missing.
+ */
+
+/** Manifest keys are Title_Case_With_Underscores, URLs are kebab-case. */
+const norm = (segment: string): string =>
+  segment.toLowerCase().replace(/[-_ ]/g, "");
+
+export function isKnownContentPath(
+  slug: readonly string[],
+  manifestKeys: readonly string[],
+): boolean {
+  if (slug.length === 0) return false;
+
+  // A section root is browsable on the strength of its folder listing, which
+  // the caller has already checked.
+  if (slug.length === 1) return true;
+
+  // An empty manifest means the fetch failed, not that the content vanished.
+  // Falling back to the old behaviour keeps an outage from turning the wiki
+  // into 404s.
+  if (manifestKeys.length === 0) return true;
+
+  const target = slug.map(norm).join("/");
+
+  return manifestKeys.some((key) => {
+    const parts = key
+      .replace(/\.mdx?$/i, "")
+      .split("/")
+      .filter(Boolean);
+    // The file itself, then every folder above it.
+    for (let i = parts.length; i >= 1; i--) {
+      if (parts.slice(0, i).map(norm).join("/") === target) return true;
+    }
+    return false;
+  });
+}

--- a/src/lib/notFoundSuggestions.ts
+++ b/src/lib/notFoundSuggestions.ts
@@ -1,0 +1,135 @@
+import type { Searcher } from "@/types";
+import {
+  normalizeQuery,
+  scoreItem,
+  searchWiki,
+  tokenizeQuery,
+} from "./wikiSearch";
+
+/**
+ * Suggested pages for a URL that returned 404.
+ *
+ * The wiki already builds a search index from the menu-titles manifest and
+ * already has a fuzzy scorer behind the nav search box, so a dead URL can be
+ * answered from data the page is holding anyway. No new endpoint, no second
+ * index. /zcash-tech/light-wallet-node ranks "Zcash Lightwallet Nodes" first,
+ * which is the page the reader was after.
+ */
+
+/** Extensions an old bookmark or an external link may still carry. */
+const TRAILING_EXTENSION = /\.(html?|md|php|aspx?)$/i;
+
+/**
+ * Suggestions are only shown when the best match clears this score.
+ *
+ * Scored against the live index, clear near-misses land far above it:
+ * "developer resources" 2359, "frost" 2226, "viewing key" 1829, "memo" 1661,
+ * "who can see payment" 1432, "block explorer" 1303, "payment procesors" 1005,
+ * "light wallet node" 812. Typed noise lands at or below it: "baz" 334,
+ * "index php" 227, "qwerty nonsense" 29, and "asdfghjkl", "wp admin",
+ * "lorem ipsum" and "1234567" match nothing at all.
+ *
+ * The two bands do overlap in the 350-430 range, and no threshold separates
+ * them cleanly: real typos "glosary" 365 and "hardware walets" 394 sit right
+ * next to junk "test123" 360 and "null" 418. The floor is set below that
+ * overlap on purpose. A weak suggestion costs a glance at a list the reader can
+ * ignore, since the search box sits directly above it, while a missing one
+ * costs the whole point of the page. What the floor is really for is the case
+ * where the scorer has nothing and names its least-bad guess anyway: offering
+ * "Namada Protocol" for /qwerty-nonsense is worse than offering nothing.
+ */
+export const MIN_SUGGESTION_SCORE = 350;
+
+/**
+ * Keep the trailing suggestions in the same league as the first one, so a
+ * single strong match doesn't drag weak ones onto the page behind it.
+ */
+export const SUGGESTION_RELATIVE_FLOOR = 0.45;
+
+export interface SuggestPagesOptions {
+  /** Most suggestions to return. */
+  limit?: number;
+  /** Absolute floor the best match must clear. */
+  minScore?: number;
+  /** Fraction of the best score a further suggestion must reach. */
+  relativeFloor?: number;
+  /** Locale prefixes to strip, for a pathname that still carries one. */
+  locales?: readonly string[];
+}
+
+const decodeSegment = (segment: string): string => {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    // A malformed escape ("%zz") throws; the raw segment is still usable.
+    return segment;
+  }
+};
+
+/**
+ * The search query a dead path implies.
+ *
+ * Only the last segment is used. Section words make the query worse rather
+ * than better, because they match a lot of pages: as a whole path,
+ * "/zcash-tech/nu-5" ranks "Zcash Resources" above "NU5", and
+ * "/using-zcash/aaaaaaa" pulls up four "Using Zcash" pages for a segment that
+ * matches nothing. The last segment on its own gets both right.
+ */
+export function pathToQuery(
+  pathname: string,
+  locales: readonly string[] = [],
+): string {
+  // Cut the query and hash before splitting, or "/zcash-tech/nu-5?ref=x#top"
+  // would make "top" the last segment.
+  const path = (pathname ?? "").split(/[?#]/)[0];
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length > 0 && locales.includes(segments[0])) {
+    segments.shift();
+  }
+
+  const last = segments[segments.length - 1];
+  if (!last) return "";
+
+  return decodeSegment(last)
+    .replace(TRAILING_EXTENSION, "")
+    .replace(/[-_+.]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Rank the search index against a dead path and return the pages worth
+ * offering, best first. An empty array means nothing was close enough, and the
+ * caller should show the search box alone rather than a bad guess.
+ */
+export function suggestPages(
+  items: readonly Searcher[],
+  pathname: string,
+  {
+    limit = 5,
+    minScore = MIN_SUGGESTION_SCORE,
+    relativeFloor = SUGGESTION_RELATIVE_FLOOR,
+    locales = [],
+  }: SuggestPagesOptions = {},
+): Searcher[] {
+  const query = pathToQuery(pathname, locales);
+  if (!query) return [];
+
+  const normalizedFull = normalizeQuery(query);
+  const tokens = tokenizeQuery(query);
+  if (!normalizedFull || !tokens.length) return [];
+
+  // searchWiki already drops non-matches and sorts by score descending.
+  const ranked = searchWiki(items, query).map((item) => ({
+    item,
+    score: scoreItem(item, normalizedFull, tokens),
+  }));
+
+  const best = ranked[0]?.score ?? 0;
+  if (best < minScore) return [];
+
+  return ranked
+    .filter((entry) => entry.score >= best * relativeFloor)
+    .slice(0, limit)
+    .map((entry) => entry.item);
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -32,6 +32,9 @@ export interface SearchInputProps {
   handleSearch: (e: ChangeEvent<HTMLInputElement>) => void;
   onKeyDown?: (e: KeyboardEvent<HTMLInputElement>) => void;
   id?: string;
+  /** Element describing the input. Lets a second instance avoid a duplicate id. */
+  hintId?: string;
+  placeholder?: string;
 }
 
 export interface SearchBarProps {


### PR DESCRIPTION
The 404 page currently ends at "Try browsing the wiki from the homepage". Someone who followed a renamed link or an old bookmark already knows what they wanted, so sending them back to the start makes them do the work again.

This reuses what the wiki already has. The 404 page builds the same search index the nav search box gets, from the same cached menu-titles manifests, and runs the dead path through the existing fuzzy scorer in `wikiSearch`. No new endpoint, no second copy of the index, no external API.

**What it does**

- Suggests pages for the dead URL. `/zcash-tech/light-wallet-node` offers "Zcash Lightwallet Nodes" first, `/using-zcash/payment-procesors` offers "Payment Processors", and `/zcash-tech/nu-5` offers NU5, NU6, NU6.1 and NU6.2.
- Puts a search box on the page, with the same fuzzy search, Enter to open the top hit, and the same result rows as the nav search.
- Falls back to the search box on its own when nothing is worth suggesting.

**The 404 page could not see the case it is for**

Worth flagging, because it changes a second file. The route only calls `notFound()` when the whole section is missing. A dead article URL inside a real section never reached the 404 page: `/zcash-tech/light-wallet-node` has no article file, but `roots` lists `Zcash_Tech` and is not empty, so it fell through to the browse view and answered HTTP 200 with "Browse the articles using the sidebar". The example in the issue was exactly that case, so without this the new page would never have shown for it.

`isKnownContentPath` decides from the menu-titles manifest, which lists every content file. A URL is known if it matches a file or any folder above one, so `/guides/frostdemo` keeps its browse view and every article keeps rendering. Only a path the manifest has never heard of is treated as missing.

It is deliberately conservative twice over. Nested articles such as `/guides/frostdemo/ywallet-frost-demo` already land on the browse view rather than their content, for reasons unrelated to routing; they match a manifest file, so this leaves them exactly as they are instead of turning a rendering bug into a 404. (Happy to look at that separately, it affects several nested paths.) And an empty manifest means the fetch failed, not that the content vanished, so that case keeps the old behaviour.

**Other decisions worth flagging**

Only the last path segment becomes the search query. Section words match too many pages to help: as a whole path, `/zcash-tech/nu-5` ranks "Zcash Resources" above NU5, and `/using-zcash/aaaaaaa` pulls up four "Using Zcash" pages for a segment that matches nothing.

Suggestions have to clear a minimum score. Without a floor the scorer always names its least-bad guess, so `/qwerty-nonsense` would offer "Namada Protocol". The floor is set from scores measured against the live index, and the comment on the constant records those numbers, including the range where genuine typos and junk overlap and why the floor sits below that range rather than above it.

**Verification**

- Checked against a running dev server over 98 URLs: 39 sampled articles, every section root, every nested folder, and known-dead paths. No page that renders content today became a 404, and the dead ones now reach the 404 page with the right suggestions.
- 34 new unit tests. `npx jest src/lib` passes 70, and tsc and eslint are clean.

**Notes**

- No dictionary changes. The UI reuses `common.search`, `searchSuggested`, `searchNoResults`, `searchTryDifferent` and `searchResultsLabel`, which all 19 locales already carry.
- `SearchInput` gained optional `hintId` and `placeholder` props so the 404 page's input cannot collide with the nav modal's element ids. Existing call sites are unchanged.
- Locale prefixes, `.html`/`.md` extensions, query strings, hashes and percent-encoded segments are all handled when reading the failed path.
