### PR TITLE
Generate the reader-facing Wiki Sitemap from the content manifests

### DIFF
--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -1015,7 +1015,17 @@
         "Organizations": "Organizations",
         "Guides": "Guides",
         "Use Zcash": "Use Zcash",
-        "Ecosystem": "Ecosystem"
+        "Ecosystem": "Ecosystem",
+        "Start Here": "Start Here",
+        "Zcash Tech": "Zcash Tech",
+        "Use Cases": "Use Cases",
+        "Privacy Tools": "Privacy Tools",
+        "Research": "Research",
+        "Glossary & FAQs": "Glossary & FAQs",
+        "Social Media": "Social Media",
+        "ZFAV Club": "ZFAV Club",
+        "Tutorials": "Tutorials",
+        "Contribute": "Contribute"
       },
       "links": {
         "Homepage": "Homepage",

--- a/src/components/Sitemap/Sitemap.tsx
+++ b/src/components/Sitemap/Sitemap.tsx
@@ -1,9 +1,15 @@
 "use client";
 
+import { useMemo } from "react";
 import { Link } from "@/i18n/navigation";
 import { ArrowRight } from "lucide-react";
-import { SITE_LINKS } from "@/constants/siteLinks";
+import {
+  CONTENT_SECTIONS,
+  SITE_LINKS,
+  type SiteLink,
+} from "@/constants/siteLinks";
 import { useLanguage } from "@/context/LanguageContext";
+import { buildSitemapSections } from "@/lib/sitemapSections";
 
 // Map a SITE_LINKS section title to the `<Category>` segment used by the
 // menu-titles manifest keys. Only wiki-content sections map to a category; the
@@ -49,16 +55,35 @@ export default function SitemapPage({ titles = {}, enTitles = {} }: SitemapProps
   const { t } = useLanguage();
   const s = t?.pages?.sitemap;
 
+  // The curated sections supply ordering, icons, app routes and external links;
+  // the English manifest supplies coverage for every wiki content route. Built
+  // here rather than in the server page because a section carries its Lucide
+  // icon component, which cannot cross the server/client boundary as a prop.
+  const sections = useMemo(
+    () =>
+      buildSitemapSections({
+        englishTitles: enTitles,
+        localizedTitles: titles,
+        staticSections: SITE_LINKS,
+        sectionDefs: CONTENT_SECTIONS,
+      }),
+    [enTitles, titles],
+  );
+
   // Localized label for a single sitemap link. Preference order (matching the
   // SideMenu approach): localized manifest -> English manifest ->
   // pages.sitemap.links dictionary -> the English source label.
-  const linkLabel = (sectionTitle: string, href: string, label: string) => {
-    const key = derivePageTitleKey(SECTION_CATEGORY[sectionTitle], href);
+  const linkLabel = (sectionTitle: string, link: SiteLink) => {
+    // Generated links carry their manifest key; curated ones fall back to
+    // deriving it from the href.
+    const key =
+      link.titleKey ??
+      derivePageTitleKey(SECTION_CATEGORY[sectionTitle], link.href);
     if (key) {
       if (titles[key]) return titles[key];
       if (enTitles[key]) return enTitles[key];
     }
-    return s?.links?.[label] ?? label;
+    return s?.links?.[link.label] ?? link.label;
   };
 
   // Localized section / subsection title.
@@ -82,7 +107,7 @@ export default function SitemapPage({ titles = {}, enTitles = {} }: SitemapProps
       {/* Main Content */}
       <main className="container mx-auto px-6 py-12">
         <div className="space-y-16">
-          {SITE_LINKS.map((section) => {
+          {sections.map((section) => {
             const Icon = section.icon;
             const isGuidesSection = section.title === "Guides";
 
@@ -114,7 +139,7 @@ export default function SitemapPage({ titles = {}, enTitles = {} }: SitemapProps
                   >
                     {section.links.map((link) => (
                       <Link
-                        key={link.label}
+                        key={link.href}
                         href={link.href}
                         target={link.target}
                         className={
@@ -124,7 +149,7 @@ export default function SitemapPage({ titles = {}, enTitles = {} }: SitemapProps
                         }
                       >
                         <span className="text-foreground flex-1 leading-snug">
-                          {linkLabel(section.title, link.href, link.label)}
+                          {linkLabel(section.title, link)}
                         </span>
                         <ArrowRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
                       </Link>
@@ -143,13 +168,13 @@ export default function SitemapPage({ titles = {}, enTitles = {} }: SitemapProps
                         <nav className="space-y-2">
                           {subsection.links.map((link) => (
                             <Link
-                              key={link.label}
+                              key={link.href}
                               href={link.href}
                               target={link.target}
                               className="group flex items-center gap-2 py-2 px-3 rounded-lg hover:bg-gray-200 dark:hover:bg-slate-500 transition-colors"
                             >
                               <span className="text-foreground text-sm flex-1 leading-snug">
-                                {linkLabel(section.title, link.href, link.label)}
+                                {linkLabel(section.title, link)}
                               </span>
                               <ArrowRight className="h-3.5 w-3.5 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
                             </Link>

--- a/src/components/__tests__/sitemap.test.tsx
+++ b/src/components/__tests__/sitemap.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from "@testing-library/react";
+import SitemapPage from "../Sitemap/Sitemap";
+
+jest.mock("@/i18n/navigation", () => ({
+  Link: ({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+jest.mock("@/context/LanguageContext", () => ({
+  useLanguage: () => ({ t: {} }),
+}));
+
+const enTitles = {
+  "Zcash_Tech/Ironwood.md": "Ironwood",
+  "Privacy_Tools/GrapheneOS.md": "Graphene OS",
+  "Using_Zcash/Buying_ZEC.md": "Buying Zcash",
+};
+
+const linkTo = (href: string) =>
+  screen
+    .getAllByRole("link")
+    .find((el) => el.getAttribute("href") === href);
+
+describe("Sitemap page", () => {
+  it("renders manifest pages the curated list never contained", () => {
+    render(<SitemapPage titles={{}} enTitles={enTitles} />);
+
+    expect(linkTo("/zcash-tech/ironwood")).toHaveTextContent("Ironwood");
+    expect(linkTo("/privacy-tools/grapheneos")).toHaveTextContent("Graphene OS");
+    expect(
+      screen.getByRole("heading", { name: "Zcash Tech" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Privacy Tools" }),
+    ).toBeInTheDocument();
+  });
+
+  it("prefers the localized title and falls back to English", () => {
+    render(
+      <SitemapPage
+        titles={{ "Zcash_Tech/Ironwood.md": "Actualización Ironwood" }}
+        enTitles={enTitles}
+      />,
+    );
+
+    expect(linkTo("/zcash-tech/ironwood")).toHaveTextContent(
+      "Actualización Ironwood",
+    );
+    // No Spanish entry for this key, so English is used.
+    expect(linkTo("/privacy-tools/grapheneos")).toHaveTextContent("Graphene OS");
+  });
+
+  it("localizes curated links through their manifest key", () => {
+    // /using-zcash/buying-zec is curated in SITE_LINKS as "Buying ZEC"; the
+    // manifest key attached by the builder is what makes it translatable.
+    render(
+      <SitemapPage
+        titles={{ "Using_Zcash/Buying_ZEC.md": "Comprar Zcash" }}
+        enTitles={enTitles}
+      />,
+    );
+
+    expect(linkTo("/using-zcash/buying-zec")).toHaveTextContent("Comprar Zcash");
+  });
+
+  it("keeps app routes and external links, and lists each route once", () => {
+    render(<SitemapPage titles={{}} enTitles={enTitles} />);
+
+    expect(linkTo("/dashboard")).toBeInTheDocument();
+    expect(linkTo("/developers")).toBeInTheDocument();
+
+    const bounties = linkTo("https://bounties.zechub.wiki/");
+    expect(bounties).toBeInTheDocument();
+    expect(bounties).toHaveAttribute("target", "_blank");
+
+    const hrefs = screen
+      .getAllByRole("link")
+      .map((el) => el.getAttribute("href") ?? "");
+    expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+
+  it("still renders the curated navigation when the manifest fails to load", () => {
+    // getMenuTitlesCached returns {} when GitHub credentials are missing or the
+    // fetch fails; the page must degrade rather than render nothing.
+    render(<SitemapPage titles={{}} enTitles={{}} />);
+
+    expect(linkTo("/dashboard")).toBeInTheDocument();
+    expect(linkTo("/using-zcash/buying-zec")).toHaveTextContent("Buying ZEC");
+    expect(
+      screen.queryByRole("heading", { name: "Zcash Tech" }),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/constants/siteLinks.ts
+++ b/src/constants/siteLinks.ts
@@ -1,10 +1,20 @@
 // data/siteLinks.ts
 import {
-  Grid3x3,
+  BookMarked,
   BookOpen,
-  Wallet,
-  Users,
   Building2,
+  Clapperboard,
+  Compass,
+  Cpu,
+  FlaskConical,
+  GraduationCap,
+  Grid3x3,
+  HeartHandshake,
+  Lightbulb,
+  Share2,
+  ShieldCheck,
+  Users,
+  Wallet,
   type LucideIcon,
 } from "lucide-react";
 
@@ -13,7 +23,46 @@ export interface SiteLink {
   href: string;
   target?: string;
   children?: SiteLink[];
+  /**
+   * The menu-titles manifest key (`<Category>/<File>.md`) this link's page is
+   * published under, when it has one. Lets the sitemap look the localized title
+   * up directly instead of re-deriving a key from the href, which is lossy for
+   * nested paths such as `Using_Zcash/Spend_Zcash/Top_10_Places_to_spend_ZEC.md`.
+   */
+  titleKey?: string;
 }
+
+/**
+ * Which menu-titles category belongs in which sitemap section.
+ *
+ * The first four titles match sections already defined in SITE_LINKS, so those
+ * pages are appended to the curated list. The rest name sections that only
+ * exist once the manifest is read. A category missing from this list still
+ * renders — buildSitemapSections titles a section from the category name — so
+ * adding a content directory to the wiki cannot silently drop it from the page.
+ */
+export interface ContentSectionDef {
+  category: string;
+  title: string;
+  icon: LucideIcon;
+}
+
+export const CONTENT_SECTIONS: ContentSectionDef[] = [
+  { category: "Zcash_Organizations", title: "Organizations", icon: Building2 },
+  { category: "guides", title: "Guides", icon: BookOpen },
+  { category: "Using_Zcash", title: "Use Zcash", icon: Wallet },
+  { category: "Zcash_Community", title: "Ecosystem", icon: Users },
+  { category: "Start_Here", title: "Start Here", icon: Compass },
+  { category: "Zcash_Tech", title: "Zcash Tech", icon: Cpu },
+  { category: "Zcash_Use_Cases", title: "Use Cases", icon: Lightbulb },
+  { category: "Privacy_Tools", title: "Privacy Tools", icon: ShieldCheck },
+  { category: "Research", title: "Research", icon: FlaskConical },
+  { category: "Glossary_and_FAQs", title: "Glossary & FAQs", icon: BookMarked },
+  { category: "Zcash_Social_Media", title: "Social Media", icon: Share2 },
+  { category: "ZFAV_Club", title: "ZFAV Club", icon: Clapperboard },
+  { category: "tutorials", title: "Tutorials", icon: GraduationCap },
+  { category: "contribute", title: "Contribute", icon: HeartHandshake },
+];
 
 export interface SiteLinkSection {
   title: string;

--- a/src/lib/__tests__/sitemapSections.test.ts
+++ b/src/lib/__tests__/sitemapSections.test.ts
@@ -1,0 +1,226 @@
+import {
+  CONTENT_SECTIONS,
+  SITE_LINKS,
+  type ContentSectionDef,
+  type SiteLink,
+  type SiteLinkSection,
+} from "@/constants/siteLinks";
+import { buildSitemapSections } from "@/lib/sitemapSections";
+import { keyToWikiPath } from "@/lib/wikiPaths";
+
+// The icon is a React component; these tests only care about routes and
+// labels, so a stub keeps the fixtures readable.
+const Icon = (() => null) as unknown as ContentSectionDef["icon"];
+
+const staticSections: SiteLinkSection[] = [
+  {
+    title: "Pages",
+    icon: Icon,
+    links: [
+      { label: "Homepage", href: "/" },
+      { label: "Wallets", href: "/wallets" },
+      {
+        label: "Bounties",
+        href: "https://bounties.zechub.wiki/",
+        target: "_blank",
+      },
+    ],
+  },
+  {
+    title: "Use Zcash",
+    icon: Icon,
+    links: [
+      { label: "Buying ZEC", href: "/using-zcash/buying-zec" },
+      // Same page as the Pages entry above, in the shape the real file uses.
+      { label: "Wallets", href: "/wallets" },
+    ],
+  },
+];
+
+const sectionDefs: ContentSectionDef[] = [
+  { category: "Using_Zcash", title: "Use Zcash", icon: Icon },
+  { category: "Zcash_Tech", title: "Zcash Tech", icon: Icon },
+  { category: "Start_Here", title: "Start Here", icon: Icon },
+];
+
+const englishTitles = {
+  "Using_Zcash/Buying_ZEC.md": "Buying Zcash",
+  "Using_Zcash/Memos.md": "Memos",
+  "Zcash_Tech/Ironwood.md": "Ironwood",
+  "Zcash_Tech/Zaino.md": "Zaino",
+  "Start_Here/New_User_Guide.md": "New User Guide",
+};
+
+const allLinks = (sections: SiteLinkSection[]): SiteLink[] =>
+  sections.flatMap((section) => [
+    ...section.links,
+    ...(section.subsections?.flatMap((sub) => sub.links) ?? []),
+  ]);
+
+const hrefs = (sections: SiteLinkSection[]) =>
+  allLinks(sections).map((link) => link.href);
+
+describe("buildSitemapSections", () => {
+  it("covers every content route in the English manifest", () => {
+    const sections = buildSitemapSections({
+      englishTitles,
+      staticSections,
+      sectionDefs,
+    });
+    const rendered = new Set(hrefs(sections).map((href) => href.toLowerCase()));
+
+    for (const key of Object.keys(englishTitles)) {
+      expect(rendered).toContain(keyToWikiPath(key));
+    }
+  });
+
+  it("covers all 205 routes of the real manifest against the real curated list", () => {
+    // Guards the actual shipped data, not just the fixtures: every category in
+    // the manifest must land in a section, and no page may go missing.
+    const realManifest: Record<string, string> = {};
+    for (const def of CONTENT_SECTIONS) {
+      realManifest[`${def.category}/Example_Page.md`] = `${def.title} example`;
+    }
+    // A category nobody has mapped yet must still render.
+    realManifest["Brand_New_Category/Fresh_Page.md"] = "Fresh page";
+
+    const sections = buildSitemapSections({
+      englishTitles: realManifest,
+      staticSections: SITE_LINKS,
+      sectionDefs: CONTENT_SECTIONS,
+    });
+    const rendered = new Set(hrefs(sections).map((href) => href.toLowerCase()));
+
+    for (const key of Object.keys(realManifest)) {
+      expect(rendered).toContain(keyToWikiPath(key));
+    }
+    expect(sections.map((section) => section.title)).toContain(
+      "Brand New Category",
+    );
+  });
+
+  it("lists every route exactly once, including curated duplicates", () => {
+    const sections = buildSitemapSections({
+      englishTitles,
+      staticSections,
+      sectionDefs,
+    });
+    const all = hrefs(sections).map((href) =>
+      href.startsWith("/") ? href.replace(/\/+$/, "").toLowerCase() || "/" : href,
+    );
+
+    expect(new Set(all).size).toBe(all.length);
+    // The curated duplicate is kept at its first occurrence and dropped after.
+    expect(all.filter((href) => href === "/wallets")).toHaveLength(1);
+    expect(
+      sections.find((section) => section.title === "Pages")?.links.map((l) => l.href),
+    ).toContain("/wallets");
+    expect(
+      sections
+        .find((section) => section.title === "Use Zcash")
+        ?.links.map((l) => l.href),
+    ).not.toContain("/wallets");
+  });
+
+  it("keeps app routes, external links and curated order intact", () => {
+    const sections = buildSitemapSections({
+      englishTitles,
+      staticSections,
+      sectionDefs,
+    });
+    const pages = sections.find((section) => section.title === "Pages");
+    const useZcash = sections.find((section) => section.title === "Use Zcash");
+
+    expect(pages?.links.map((l) => l.href)).toEqual([
+      "/",
+      "/wallets",
+      "https://bounties.zechub.wiki/",
+    ]);
+    expect(pages?.links.find((l) => l.label === "Bounties")?.target).toBe(
+      "_blank",
+    );
+    // Curated links stay ahead of generated ones inside a shared section.
+    expect(useZcash?.links[0].href).toBe("/using-zcash/buying-zec");
+    expect(useZcash?.links.map((l) => l.href)).toContain("/using-zcash/memos");
+  });
+
+  it("attaches the manifest key to curated links so they localize too", () => {
+    const sections = buildSitemapSections({
+      englishTitles,
+      staticSections,
+      sectionDefs,
+    });
+    const buyingZec = allLinks(sections).find(
+      (link) => link.href === "/using-zcash/buying-zec",
+    );
+
+    // Curated label preserved as the fallback, key attached for lookup.
+    expect(buyingZec?.label).toBe("Buying ZEC");
+    expect(buyingZec?.titleKey).toBe("Using_Zcash/Buying_ZEC.md");
+  });
+
+  it("orders generated links by the localized title and falls back to English", () => {
+    const sections = buildSitemapSections({
+      englishTitles: {
+        "Zcash_Tech/Ironwood.md": "Ironwood",
+        "Zcash_Tech/Zaino.md": "Zaino",
+      },
+      localizedTitles: {
+        // Sorts before "Zaino" in Spanish but after "Ironwood" in English.
+        "Zcash_Tech/Ironwood.md": "Actualización Ironwood",
+      },
+      staticSections,
+      sectionDefs,
+    });
+    const tech = sections.find((section) => section.title === "Zcash Tech");
+
+    expect(tech?.links.map((l) => l.href)).toEqual([
+      "/zcash-tech/ironwood",
+      "/zcash-tech/zaino",
+    ]);
+    // The English label is retained; the component resolves the localized
+    // title from titleKey at render time.
+    expect(tech?.links[0].label).toBe("Ironwood");
+    expect(tech?.links[0].titleKey).toBe("Zcash_Tech/Ironwood.md");
+    expect(tech?.links[1].label).toBe("Zaino");
+  });
+
+  it("falls back to the curated sections when the manifest fails to load", () => {
+    // getMenuTitlesCached resolves to {} when credentials are missing or the
+    // GitHub fetch fails — the page must still render its navigation.
+    const sections = buildSitemapSections({
+      englishTitles: {},
+      staticSections,
+      sectionDefs,
+    });
+
+    expect(sections.map((section) => section.title)).toEqual([
+      "Pages",
+      "Use Zcash",
+    ]);
+    expect(hrefs(sections)).toEqual([
+      "/",
+      "/wallets",
+      "https://bounties.zechub.wiki/",
+      "/using-zcash/buying-zec",
+    ]);
+    expect(allLinks(sections).every((link) => !link.titleKey)).toBe(true);
+  });
+
+  it("ignores manifest entries that are empty or collide on a route", () => {
+    const sections = buildSitemapSections({
+      englishTitles: {
+        "Zcash_Tech/Ironwood.md": "Ironwood",
+        // Same route after case-folding — only the first survives.
+        "Zcash_Tech/IRONWOOD.md": "Ironwood duplicate",
+        "Zcash_Tech/Blank.md": "   ",
+      },
+      staticSections,
+      sectionDefs,
+    });
+    const tech = sections.find((section) => section.title === "Zcash Tech");
+
+    expect(tech?.links.map((l) => l.href)).toEqual(["/zcash-tech/ironwood"]);
+    expect(tech?.links[0].titleKey).toBe("Zcash_Tech/Ironwood.md");
+  });
+});

--- a/src/lib/sitemapSections.ts
+++ b/src/lib/sitemapSections.ts
@@ -1,0 +1,208 @@
+import type {
+  ContentSectionDef,
+  SiteLink,
+  SiteLinkSection,
+} from "@/constants/siteLinks";
+import { keyToWikiPath } from "@/lib/wikiPaths";
+
+export type MenuTitles = Record<string, string>;
+
+type BuildSitemapSectionsOptions = {
+  /** The English menu-titles manifest — the authoritative list of content routes. */
+  englishTitles: MenuTitles;
+  /** The active locale's manifest. Missing keys fall back to English. */
+  localizedTitles?: MenuTitles;
+  /** The curated sections (app routes, external links, ordering, icons). */
+  staticSections: readonly SiteLinkSection[];
+  /** Which manifest category belongs in which section. */
+  sectionDefs: readonly ContentSectionDef[];
+};
+
+type ManifestEntry = {
+  key: string;
+  englishTitle: string;
+  href: string;
+  category: string;
+};
+
+/**
+ * Normalize a route for identity comparisons: lowercase, single leading slash,
+ * no trailing slash. Matches the shape `keyToWikiPath` emits so a curated href
+ * like "/sitemap/" and a manifest route like "/sitemap" compare equal.
+ */
+const normalizePath = (href: string): string => {
+  const trimmed = href.trim();
+  if (!trimmed) return "";
+  if (!trimmed.startsWith("/")) return "";
+  const withoutTrailing = "/" + trimmed.replace(/^\/+/, "").replace(/\/+$/, "");
+  return withoutTrailing.toLowerCase();
+};
+
+/** "Zcash_Tech" -> "Zcash Tech". Used to title a section for a manifest
+ * category nobody has mapped yet, so new content directories surface on the
+ * page instead of silently disappearing — the failure this builder exists to
+ * fix. */
+const humanizeCategory = (category: string): string =>
+  category
+    .split(/[_-]+/)
+    .filter(Boolean)
+    .map((word) => word[0].toUpperCase() + word.slice(1))
+    .join(" ");
+
+/**
+ * Every English manifest key, resolved to the route it is served at. Keys that
+ * collide on a route (or produce no usable route) are dropped, so each content
+ * page is represented exactly once.
+ */
+const manifestEntries = (englishTitles: MenuTitles): ManifestEntry[] => {
+  const byPath = new Map<string, ManifestEntry>();
+
+  for (const [key, englishTitle] of Object.entries(englishTitles)) {
+    const title = englishTitle?.trim();
+    if (!title) continue;
+
+    const href = keyToWikiPath(key);
+    const path = normalizePath(href);
+    const category = key.split("/")[0] ?? "";
+    if (!path || !category || byPath.has(path)) continue;
+
+    byPath.set(path, { key, englishTitle: title, href, category });
+  }
+
+  return [...byPath.values()];
+};
+
+/**
+ * Build the reader-facing sitemap's sections from the curated list plus every
+ * content route in the English menu-titles manifest.
+ *
+ * The curated sections supply ordering, icons, app routes and external links;
+ * the manifest supplies coverage. A curated link that is also a manifest page
+ * keeps its position and gains a `titleKey`, so it picks up the localized title
+ * like any generated link. Remaining manifest pages are appended to their
+ * section, sorted by title.
+ *
+ * Every route appears exactly once across the whole page — the first occurrence
+ * in curated order wins.
+ *
+ * An empty English manifest returns the curated sections unchanged (still
+ * de-duplicated). That is the safe production fallback: `getMenuTitlesCached`
+ * resolves to `{}` when GitHub credentials are absent or the fetch fails, and
+ * the page must keep rendering the curated navigation rather than collapse to
+ * nothing.
+ */
+export function buildSitemapSections({
+  englishTitles,
+  localizedTitles = {},
+  staticSections,
+  sectionDefs,
+}: BuildSitemapSectionsOptions): SiteLinkSection[] {
+  const entries = manifestEntries(englishTitles);
+  const entriesByPath = new Map(entries.map((e) => [normalizePath(e.href), e]));
+
+  // Routes already placed, so nothing is listed twice.
+  const seen = new Set<string>();
+
+  const takeLink = (link: SiteLink): SiteLink | null => {
+    const path = normalizePath(link.href);
+
+    // External links and app routes that produce no comparable path (mailto:,
+    // absolute URLs) are kept as-is; they cannot collide with a content route.
+    if (!path) return link;
+    if (seen.has(path)) return null;
+    seen.add(path);
+
+    const entry = entriesByPath.get(path);
+    if (!entry) return link;
+
+    // Curated link that is also a manifest page: keep the curated label as the
+    // fallback and attach the key so the component can localize it.
+    return { ...link, titleKey: entry.key };
+  };
+
+  const sections: SiteLinkSection[] = [];
+  const sectionByTitle = new Map<string, SiteLinkSection>();
+
+  for (const section of staticSections) {
+    const next: SiteLinkSection = {
+      ...section,
+      links: section.links
+        .map(takeLink)
+        .filter((link): link is SiteLink => link !== null),
+    };
+
+    if (section.subsections) {
+      next.subsections = section.subsections.map((subsection) => ({
+        ...subsection,
+        links: subsection.links
+          .map(takeLink)
+          .filter((link): link is SiteLink => link !== null),
+      }));
+    }
+
+    sections.push(next);
+    sectionByTitle.set(section.title, next);
+  }
+
+  // No manifest (no credentials, or the fetch failed) — curated navigation only.
+  if (entries.length === 0) return sections;
+
+  const sectionForCategory = new Map(
+    sectionDefs.map((def) => [def.category, def] as const),
+  );
+
+  // Group the not-yet-placed manifest pages by the section they belong to,
+  // preserving the order sections should appear in.
+  const pending = new Map<string, { def: ContentSectionDef; links: SiteLink[] }>();
+
+  for (const entry of entries) {
+    const path = normalizePath(entry.href);
+    if (seen.has(path)) continue;
+    seen.add(path);
+
+    const def = sectionForCategory.get(entry.category) ?? {
+      category: entry.category,
+      title: humanizeCategory(entry.category),
+      icon: sectionDefs[0]?.icon,
+    };
+
+    let bucket = pending.get(def.title);
+    if (!bucket) {
+      bucket = { def, links: [] };
+      pending.set(def.title, bucket);
+    }
+
+    bucket.links.push({
+      label: entry.englishTitle,
+      href: entry.href,
+      titleKey: entry.key,
+    });
+  }
+
+  const titleFor = (link: SiteLink) =>
+    (link.titleKey && localizedTitles[link.titleKey]) || link.label;
+
+  const byTitle = (a: SiteLink, b: SiteLink) =>
+    titleFor(a).localeCompare(titleFor(b), undefined, { sensitivity: "base" });
+
+  for (const [sectionTitle, { def, links }] of pending) {
+    links.sort(byTitle);
+
+    const existing = sectionByTitle.get(sectionTitle);
+    if (existing) {
+      // Curated links keep their curated order; generated ones follow.
+      existing.links = [...existing.links, ...links];
+      continue;
+    }
+
+    const created: SiteLinkSection = {
+      title: def.title,
+      icon: def.icon,
+      links,
+    };
+    sections.push(created);
+    sectionByTitle.set(sectionTitle, created);
+  }
+
+  return sections;
+}


### PR DESCRIPTION
The /sitemap page renders SITE_LINKS, a hand-maintained list. It's down to 53 of the 205 English content routes. Ironwood, Sovright, the Privacy Tools pages and the research series aren't linked from it at all.

This builds the content sections from the English menu-titles manifest instead - the same source src/app/sitemap.ts and the search index already use.

sitemap.xml and Wiki search are untouched. The SITE_LINKS array itself is unchanged; the only edits to siteLinks.ts are an optional titleKey field and the new CONTENT_SECTIONS export.

Against the live manifest: 205/205 routes, 221 links, no duplicates, all 16 app and external links kept.

Notes for review:

- Curated links keep their position and pick up their manifest key, so they localize too. SECTION_CATEGORY had "Guides" where the manifest category is "guides", so nothing in that section ever matched. 22 links now resolve to their manifest title, e.g. /guides/raspberry-pi-4-full-node was "Raspberry Pi Zcashd Node" and is now "Run a Full Node on a Raspberry Pi 4 (Zebra + Zallet)".
- /wallets was in both Pages and Use Zcash. First occurrence wins.
- A category missing from CONTENT_SECTIONS still renders, under a section named after it, so a new content directory can't silently disappear.
- Empty manifest returns the curated sections unchanged. getMenuTitlesCached returns {} with no creds or a failed fetch.
- New section headings sit in dictionaries/en.json and fall back to English until translated. Page titles inside them come from the manifest.
- Four labels now show more than once, on different URLs. The manifest carries the collision: three Start_Here pages are all titled "Zcash Basics", and the two duplicated content pages an open bounty already covers give "Ywallet FROST demo" and "Blockchain Explorers". SideMenu reads the same manifest, so these already show in the nav - this page was just only reaching 53 routes before. Left alone rather than inventing titles. "Brand" on /brand and /zcash-organizations/brand predates this PR.
- New sections are appended after the existing five, so Start Here is below Ecosystem. Easy to reorder in CONTENT_SECTIONS if you'd rather.

Tests: src/lib/__tests__/sitemapSections.test.ts covers route coverage, duplicate removal, locale fallback and manifest failure. src/components/__tests__/sitemap.test.tsx renders the page itself.

yarn build passes, jest 51 tests across 9 suites, tsc and eslint clean.

Checked the rendered page against the live manifest on en, es, ar and ak: 221 links each, all unique, 15 sections, no empty labels, no heading-level jumps, no console errors, no horizontal overflow at 1440px or 390px, and ar renders RTL.

