### PR TITLE
Add a site-wide keyboard skip-to-content link

### DIFF
--- a/dictionaries/ar.json
+++ b/dictionaries/ar.json
@@ -149,7 +149,8 @@
     "searchNoResults": "لا توجد صفحات مطابقة",
     "searchTryDifferent": "جرّب استعلامات أقصر أو مرادفات أو كلمات مختلفة.",
     "searchSuggested": "الصفحات المقترحة",
-    "searchResultsLabel": "النتائج"
+    "searchResultsLabel": "النتائج",
+    "skipToContent": "تخطي إلى المحتوى"
   },
   "navigation": {
     "wallets": "المحافظ",

--- a/dictionaries/de.json
+++ b/dictionaries/de.json
@@ -149,7 +149,8 @@
     "searchNoResults": "Keine passenden Seiten",
     "searchTryDifferent": "Versuche kürzere Suchanfragen, Synonyme oder andere Wörter.",
     "searchSuggested": "Vorgeschlagene Seiten",
-    "searchResultsLabel": "Ergebnisse"
+    "searchResultsLabel": "Ergebnisse",
+    "skipToContent": "Zum Inhalt springen"
   },
   "navigation": {
     "wallets": "Wallets",

--- a/dictionaries/en.json
+++ b/dictionaries/en.json
@@ -137,7 +137,8 @@
     "searchNoResults": "No matching pages",
     "searchTryDifferent": "Try shorter queries, synonyms, or different words.",
     "searchSuggested": "Suggested pages",
-    "searchResultsLabel": "Results"
+    "searchResultsLabel": "Results",
+    "skipToContent": "Skip to content"
   },
   "navigation": {
     "wallets": "Wallets",

--- a/dictionaries/es.json
+++ b/dictionaries/es.json
@@ -149,7 +149,8 @@
     "searchNoResults": "No hay páginas coincidentes",
     "searchTryDifferent": "Prueba consultas más cortas, sinónimos u otras palabras.",
     "searchSuggested": "Páginas sugeridas",
-    "searchResultsLabel": "Resultados"
+    "searchResultsLabel": "Resultados",
+    "skipToContent": "Saltar al contenido"
   },
   "navigation": {
     "wallets": "Carteras",

--- a/dictionaries/fr.json
+++ b/dictionaries/fr.json
@@ -149,7 +149,8 @@
     "searchNoResults": "Aucune page correspondante",
     "searchTryDifferent": "Essayez des requêtes plus courtes, des synonymes ou d'autres mots.",
     "searchSuggested": "Pages suggérées",
-    "searchResultsLabel": "Résultats"
+    "searchResultsLabel": "Résultats",
+    "skipToContent": "Aller au contenu"
   },
   "navigation": {
     "wallets": "Portefeuilles",

--- a/dictionaries/hi.json
+++ b/dictionaries/hi.json
@@ -149,7 +149,8 @@
     "searchNoResults": "कोई मेल खाते पृष्ठ नहीं",
     "searchTryDifferent": "छोटे प्रश्न, समानार्थी शब्द, या अलग शब्द आज़माएँ।",
     "searchSuggested": "सुझाए गए पृष्ठ",
-    "searchResultsLabel": "परिणाम"
+    "searchResultsLabel": "परिणाम",
+    "skipToContent": "सामग्री पर जाएँ"
   },
   "navigation": {
     "wallets": "Wallets",

--- a/dictionaries/it.json
+++ b/dictionaries/it.json
@@ -149,7 +149,8 @@
     "searchNoResults": "Nessuna pagina trovata",
     "searchTryDifferent": "Prova query più brevi, sinonimi o parole diverse.",
     "searchSuggested": "Pagine suggerite",
-    "searchResultsLabel": "Risultati"
+    "searchResultsLabel": "Risultati",
+    "skipToContent": "Vai al contenuto"
   },
   "navigation": {
     "wallets": "Wallet",

--- a/dictionaries/ja.json
+++ b/dictionaries/ja.json
@@ -149,7 +149,8 @@
     "searchNoResults": "一致するページがありません",
     "searchTryDifferent": "より短いクエリ、同義語、または別の単語を試してください。",
     "searchSuggested": "おすすめのページ",
-    "searchResultsLabel": "結果"
+    "searchResultsLabel": "結果",
+    "skipToContent": "コンテンツにスキップ"
   },
   "navigation": {
     "wallets": "ウォレット",

--- a/dictionaries/ko.json
+++ b/dictionaries/ko.json
@@ -149,7 +149,8 @@
     "searchNoResults": "일치하는 페이지 없음",
     "searchTryDifferent": "더 짧은 검색어, 동의어 또는 다른 단어를 사용해 보세요.",
     "searchSuggested": "추천 페이지",
-    "searchResultsLabel": "결과"
+    "searchResultsLabel": "결과",
+    "skipToContent": "본문 바로가기"
   },
   "navigation": {
     "wallets": "지갑",

--- a/dictionaries/pt.json
+++ b/dictionaries/pt.json
@@ -149,7 +149,8 @@
     "searchNoResults": "Nenhuma página correspondente",
     "searchTryDifferent": "Tente consultas mais curtas, sinônimos ou palavras diferentes.",
     "searchSuggested": "Páginas sugeridas",
-    "searchResultsLabel": "Resultados"
+    "searchResultsLabel": "Resultados",
+    "skipToContent": "Ir para o conteúdo"
   },
   "navigation": {
     "wallets": "Carteiras",

--- a/dictionaries/ru.json
+++ b/dictionaries/ru.json
@@ -149,7 +149,8 @@
     "searchNoResults": "Нет совпадающих страниц",
     "searchTryDifferent": "Попробуйте более короткие запросы, синонимы или другие слова.",
     "searchSuggested": "Рекомендуемые страницы",
-    "searchResultsLabel": "Результаты"
+    "searchResultsLabel": "Результаты",
+    "skipToContent": "Перейти к содержимому"
   },
   "navigation": {
     "wallets": "Кошельки",

--- a/dictionaries/sw.json
+++ b/dictionaries/sw.json
@@ -149,7 +149,8 @@
     "searchNoResults": "Hakuna kurasa zinazofanana",
     "searchTryDifferent": "Jaribu maswali mafupi, maneno yanayofanana, au maneno tofauti.",
     "searchSuggested": "Kurasa zilizopendekezwa",
-    "searchResultsLabel": "Matokeo"
+    "searchResultsLabel": "Matokeo",
+    "skipToContent": "Nenda kwenye maudhui"
   },
   "navigation": {
     "wallets": "Mkoba",

--- a/dictionaries/tr.json
+++ b/dictionaries/tr.json
@@ -149,7 +149,8 @@
     "searchNoResults": "Eşleşen sayfa yok",
     "searchTryDifferent": "Daha kısa sorgular, eş anlamlılar veya farklı kelimeler deneyin.",
     "searchSuggested": "Önerilen sayfalar",
-    "searchResultsLabel": "Sonuçlar"
+    "searchResultsLabel": "Sonuçlar",
+    "skipToContent": "İçeriğe atla"
   },
   "navigation": {
     "wallets": "Cüzdanlar",

--- a/dictionaries/uk.json
+++ b/dictionaries/uk.json
@@ -149,7 +149,8 @@
     "searchNoResults": "Немає сторінок, що збігаються",
     "searchTryDifferent": "Спробуйте коротші запити, синоніми або інші слова.",
     "searchSuggested": "Рекомендовані сторінки",
-    "searchResultsLabel": "Результати"
+    "searchResultsLabel": "Результати",
+    "skipToContent": "Перейти до вмісту"
   },
   "navigation": {
     "wallets": "Гаманці",

--- a/dictionaries/zh.json
+++ b/dictionaries/zh.json
@@ -149,7 +149,8 @@
     "searchNoResults": "没有匹配的页面",
     "searchTryDifferent": "请尝试更短的查询词、同义词或其他词语。",
     "searchSuggested": "推荐页面",
-    "searchResultsLabel": "结果"
+    "searchResultsLabel": "结果",
+    "skipToContent": "跳到内容"
   },
   "navigation": {
     "wallets": "钱包",

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -5,6 +5,7 @@ import { Metadata } from "next";
 import { Inter } from "next/font/google";
 import "./globals.css";
 import NavigationWrapper from "@/components/NavigationWrapper";
+import SkipToContent from "@/components/SkipToContent";
 import { ThemeProvider } from "next-themes";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
@@ -114,6 +115,13 @@ export default async function RootLayout({
         />
       </head>
       <body className={`px-0 ${inter.className} dark:bg-slate-900 dark:text-white`}>
+        {/* First focusable element on the page, so keyboard and screen-reader
+            users can bypass the header, menus and search (WCAG 2.4.1). Rendered
+            here rather than inside the providers so nothing precedes it in the
+            tab order. */}
+        <SkipToContent
+          label={(initialDictionary as Record<string, any>)?.common?.skipToContent}
+        />
         <NextIntlClientProvider>
           <ThemeProvider
             attribute="class"

--- a/src/components/NavigationWrapper.tsx
+++ b/src/components/NavigationWrapper.tsx
@@ -3,6 +3,7 @@ import { usePathname } from "@/i18n/navigation";
 import { Footer, Navigation } from "@/components";
 import FloatingExplore from "@/components/FloatingExplore";
 import ProgressBar from "@/components/UI/ProgressBar";
+import { MAIN_CONTENT_ID } from "@/components/SkipToContent";
 import type { Searcher } from "@/types";
 
 const EXEMPT_ROUTES = ["/welcome"];
@@ -26,7 +27,13 @@ export default function NavigationWrapper({
             <Navigation searchItems={searchItems} />
             <FloatingExplore />
 
-            <div className="flex flex-col justify-between grow">{children}</div>
+            <div
+              id={MAIN_CONTENT_ID}
+              tabIndex={-1}
+              className="flex flex-col justify-between grow scroll-mt-24"
+            >
+              {children}
+            </div>
           </div>
 
           <Footer />
@@ -34,7 +41,13 @@ export default function NavigationWrapper({
       )}
 
       {isExempt && (
-        <div className="flex flex-col justify-between grow">{children}</div>
+        <div
+          id={MAIN_CONTENT_ID}
+          tabIndex={-1}
+          className="flex flex-col justify-between grow scroll-mt-24"
+        >
+          {children}
+        </div>
       )}
     </>
   );

--- a/src/components/SkipToContent.tsx
+++ b/src/components/SkipToContent.tsx
@@ -1,0 +1,48 @@
+/**
+ * Site-wide "skip to content" link (WCAG 2.4.1 Bypass Blocks).
+ *
+ * Rendered as the first child of <body> in the locale layout so it is the first
+ * focusable element on every page, ahead of the header, menus and search. It is
+ * hidden until focused, then pinned to the top of the viewport above the sticky
+ * header, and moves focus to the shared content wrapper when activated.
+ *
+ * Two styling constraints shape the classes below:
+ *   - globals.css resets `outline` to none with !important on every element, so
+ *     the focused state has to be carried by background, border and ring
+ *     (box-shadow) rather than an outline.
+ *   - the header is `sticky top-0 z-200` and the mobile drawer is z-201, so the
+ *     focused link sits above both.
+ *
+ * No client JavaScript: the target carries tabIndex={-1}, which is what lets a
+ * plain in-page anchor move focus and not just scroll.
+ */
+
+/** id of the element the skip link targets. Imported by the content wrapper so
+ * the link and its target cannot drift apart. */
+export const MAIN_CONTENT_ID = "main-content";
+
+export const SKIP_TO_CONTENT_FALLBACK = "Skip to content";
+
+export default function SkipToContent({ label }: { label?: string }) {
+  return (
+    <a
+      href={`#${MAIN_CONTENT_ID}`}
+      data-testid="skip-to-content"
+      className={[
+        // Hidden during normal browsing, but present for keyboard users.
+        "sr-only",
+        // Revealed on focus, above the sticky header and the mobile drawer.
+        "focus:not-sr-only focus:fixed focus:top-4 focus:start-4 focus:z-[300]",
+        "focus:inline-flex focus:items-center focus:h-auto focus:w-auto",
+        "focus:px-4 focus:py-2 focus:m-0 focus:overflow-visible focus:whitespace-nowrap",
+        "focus:rounded-md focus:text-sm focus:font-medium focus:no-underline",
+        "focus:bg-white focus:text-slate-900",
+        "dark:focus:bg-slate-900 dark:focus:text-white",
+        "focus:border focus:border-slate-300 dark:focus:border-slate-600",
+        "focus:shadow-lg focus:ring-2 focus:ring-[#F4B728]",
+      ].join(" ")}
+    >
+      {label?.trim() || SKIP_TO_CONTENT_FALLBACK}
+    </a>
+  );
+}

--- a/src/components/__tests__/skipToContent.test.tsx
+++ b/src/components/__tests__/skipToContent.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SkipToContent, {
+  MAIN_CONTENT_ID,
+  SKIP_TO_CONTENT_FALLBACK,
+} from "../SkipToContent";
+
+describe("SkipToContent", () => {
+  it("points at the shared content wrapper", () => {
+    render(<SkipToContent />);
+
+    expect(screen.getByRole("link")).toHaveAttribute(
+      "href",
+      `#${MAIN_CONTENT_ID}`,
+    );
+  });
+
+  it("uses the localized label and falls back to English", () => {
+    const { unmount } = render(<SkipToContent label="Saltar al contenido" />);
+    expect(screen.getByRole("link")).toHaveTextContent("Saltar al contenido");
+    unmount();
+
+    // A locale with no entry for the key, or a whitespace-only one, must not
+    // render an empty link — getDictionary returns undefined for missing keys.
+    for (const label of [undefined, "", "   "]) {
+      const { unmount: u } = render(<SkipToContent label={label} />);
+      expect(screen.getByRole("link")).toHaveTextContent(
+        SKIP_TO_CONTENT_FALLBACK,
+      );
+      u();
+    }
+  });
+
+  it("is hidden until focused, then revealed", () => {
+    render(<SkipToContent />);
+    const link = screen.getByRole("link");
+
+    // Visually hidden but still in the accessibility tree and tab order, which
+    // is what lets a keyboard user reach it.
+    expect(link).toHaveClass("sr-only");
+    expect(link).not.toHaveAttribute("aria-hidden");
+    expect(link).not.toHaveAttribute("tabindex");
+
+    // Revealed on focus, above the sticky header (z-200) and drawer (z-201).
+    expect(link.className).toContain("focus:not-sr-only");
+    expect(link.className).toContain("focus:z-[300]");
+    // globals.css resets outline with !important, so the focus affordance has
+    // to come from a ring/background rather than an outline.
+    expect(link.className).toContain("focus:ring-2");
+    expect(link.className).toContain("focus:bg-white");
+    // Logical inset so the link flips side in RTL locales.
+    expect(link.className).toContain("focus:start-4");
+  });
+
+  it("is the first element a keyboard user reaches", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <SkipToContent />
+        <header>
+          <a href="#wallets">Wallets</a>
+          <button type="button">Search</button>
+        </header>
+        <div id={MAIN_CONTENT_ID} tabIndex={-1}>
+          <a href="#in-content">In content</a>
+        </div>
+      </>,
+    );
+
+    await user.tab();
+
+    expect(screen.getByRole("link", { name: SKIP_TO_CONTENT_FALLBACK })).toHaveFocus();
+  });
+
+  it("moves focus into the content wrapper when activated", async () => {
+    const user = userEvent.setup();
+    render(
+      <>
+        <SkipToContent />
+        <header>
+          <a href="#wallets">Wallets</a>
+        </header>
+        <div id={MAIN_CONTENT_ID} tabIndex={-1}>
+          <a href="#in-content">In content</a>
+        </div>
+      </>,
+    );
+
+    const target = document.getElementById(MAIN_CONTENT_ID)!;
+    // jsdom does not implement fragment navigation, so assert the contract the
+    // browser relies on: the target is programmatically focusable, and the next
+    // tab stop from there is inside the content rather than back in the header.
+    expect(target).toHaveAttribute("tabindex", "-1");
+    target.focus();
+    expect(target).toHaveFocus();
+
+    await user.tab();
+    expect(screen.getByRole("link", { name: "In content" })).toHaveFocus();
+  });
+});


### PR DESCRIPTION
Keyboard and screen-reader users have to tab through the header, menus and search on every page before reaching the article or tool they opened. There was no way to bypass it (WCAG 2.4.1).

Adds one link in the locale layout, as the first child of <body> so nothing precedes it in the tab order, and gives the shared content wrapper in NavigationWrapper an id and tabIndex={-1}. The tabindex is what makes activating the link move focus rather than only scroll. No client JavaScript, and no page or article touched.

Notes for review:

- globals.css resets outline to none with !important on every element, so the focus affordance is a ring and background rather than an outline. That reset removes the focus indicator site-wide, not just here - worth its own look.
- z-300, because the header is z-200 and the mobile drawer z-201.
- focus:start-4 is a logical inset, so the link sits top-right in ar.
- scroll-mt-24 on the wrapper is load-bearing, not decoration: without it the fragment jump parks the content 88px under the sticky header.
- Both NavigationWrapper branches carry the target, so it also works on /welcome, which renders without navigation.
- Label is common.skipToContent, translated in 15 locales. ak, ee, ig and yo fall back to English - better that a speaker fills those in than I guess at an accessibility string.
- Tests are in src/components/__tests__, which the Unit tests workflow does not run - its scope is jest src/lib. Its comment says the testing-library packages are undeclared; they are declared now, at yarn.lock 3263, 3275 and 3282.

Checked against production builds of this branch and of main. axe-core: the skip-link rule passes here and did not apply before, and bypass goes from incomplete to passing on /dashboard. The accessibility tree exposes it as role=link, name "Skip to content", ignored=false, and it is the first link in the tree where main has "Logo". Egress and check-menu-labels come out identical either way. Also walked it in a browser on five routes, in en, es and ar, at 1440px and 390px, light and dark, and with JavaScript off.

yarn build passes, jest 43 tests across 8 suites, tsc and eslint clean.
