### PR TITLE
Respect the system reduce-motion setting site-wide

### DIFF
--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -855,3 +855,34 @@ h2:has(img.processor-logo) > a:hover {
 .processor-note p {
   margin: 0;
 }
+
+/* ---------------------------------------------------------------------------
+   Reduced motion.
+
+   Framer Motion is handled separately, site-wide, by MotionProvider
+   (reducedMotion="user"). This block covers everything Framer does not: CSS
+   transitions, CSS keyframes, and the smooth scrolling set on html above.
+
+   Durations collapse rather than animations being removed, so an element that
+   fades in with CSS still ends up visible - the same reason MotionProvider
+   keeps opacity animating.
+
+   .animate-spin is deliberately exempt. A spinner reports that something is
+   still happening, and freezing one part-way through a rotation reads as a
+   broken page rather than a calmer one.
+   --------------------------------------------------------------------------- */
+@media (prefers-reduced-motion: reduce) {
+  *:not(.animate-spin),
+  *:not(.animate-spin)::before,
+  *:not(.animate-spin)::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+  }
+
+  html {
+    scroll-behavior: auto !important;
+  }
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -6,6 +6,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import NavigationWrapper from "@/components/NavigationWrapper";
 import SkipToContent from "@/components/SkipToContent";
+import MotionProvider from "@/components/MotionProvider";
 import { ThemeProvider } from "next-themes";
 import { hasLocale, NextIntlClientProvider } from "next-intl";
 import { setRequestLocale } from "next-intl/server";
@@ -135,9 +136,11 @@ export default async function RootLayout({
               initialDictionary={initialDictionary}
             >
               <DarkModeProvider>
-                <NavigationWrapper searchItems={searchItems}>
-                  {children}
-                </NavigationWrapper>
+                <MotionProvider>
+                  <NavigationWrapper searchItems={searchItems}>
+                    {children}
+                  </NavigationWrapper>
+                </MotionProvider>
               </DarkModeProvider>
             </LanguageProvider>
           </ThemeProvider>

--- a/src/components/MotionProvider.tsx
+++ b/src/components/MotionProvider.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+
+/**
+ * Site-wide reduced-motion configuration for Framer Motion.
+ *
+ * `reducedMotion="user"` makes every `motion` component in the tree follow the
+ * operating system's "Reduce motion" setting, so the ~100 files that import
+ * framer-motion do not each have to handle it.
+ *
+ * What it actually does (motion-dom's animateTarget): when the preference is
+ * on, any positional key — width, height, top, left, right, bottom and every
+ * transform prop (x, y, scale, rotate, …) — is animated with `{ type: false }`,
+ * which sets it to its target value immediately instead of tweening. Every other
+ * key, opacity included, still animates.
+ *
+ * That distinction is what keeps the visualizers usable. The codebase has
+ * hundreds of `initial={{ opacity: 0, y: 20 }}` entrances; under this config the
+ * slide is removed while the fade still runs, so content and interactive steps
+ * still appear rather than being stranded invisible.
+ *
+ * Note: framer-motion reads the preference when a component mounts and does not
+ * subscribe to changes, so toggling the OS setting applies on the next page
+ * load. The CSS half of this (globals.css) is live either way.
+ */
+export default function MotionProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <MotionConfig reducedMotion="user">{children}</MotionConfig>;
+}

--- a/src/components/__tests__/motionProvider.test.tsx
+++ b/src/components/__tests__/motionProvider.test.tsx
@@ -1,0 +1,73 @@
+import fs from "fs";
+import path from "path";
+import { useContext } from "react";
+import { render, screen } from "@testing-library/react";
+import { MotionConfigContext } from "framer-motion";
+import MotionProvider from "../MotionProvider";
+
+function ReadConfig() {
+  const { reducedMotion } = useContext(MotionConfigContext);
+  return <span data-testid="cfg">{String(reducedMotion)}</span>;
+}
+
+describe("MotionProvider", () => {
+  it("puts every motion component under the user's system preference", () => {
+    render(
+      <MotionProvider>
+        <ReadConfig />
+      </MotionProvider>,
+    );
+
+    // "user" rather than "always": motion-dom only replaces the transition for
+    // positional keys (transforms, width/height/top/left/right/bottom) with
+    // { type: false }. Opacity keeps animating, which is what stops the
+    // hundreds of `initial={{ opacity: 0 }}` entrances from stranding their
+    // content invisible.
+    expect(screen.getByTestId("cfg")).toHaveTextContent("user");
+  });
+
+  it("defaults to never without the provider, so the wrapper is load-bearing", () => {
+    render(<ReadConfig />);
+
+    expect(screen.getByTestId("cfg")).toHaveTextContent("never");
+  });
+
+  it("renders its children unchanged", () => {
+    render(
+      <MotionProvider>
+        <p>Visualizer content</p>
+      </MotionProvider>,
+    );
+
+    expect(screen.getByText("Visualizer content")).toBeInTheDocument();
+  });
+});
+
+describe("reduced-motion stylesheet", () => {
+  const css = fs.readFileSync(
+    path.join(process.cwd(), "src/app/[locale]/globals.css"),
+    "utf8",
+  );
+  const block =
+    css.slice(css.indexOf("@media (prefers-reduced-motion: reduce)")) || "";
+
+  it("collapses CSS transitions and animations", () => {
+    expect(css).toContain("@media (prefers-reduced-motion: reduce)");
+    expect(block).toContain("transition-duration: 0.01ms !important");
+    expect(block).toContain("animation-duration: 0.01ms !important");
+    // Durations collapse rather than `animation: none`, so a CSS fade-in still
+    // ends with the element visible instead of stuck at its start frame.
+    expect(block).not.toContain("animation: none");
+    expect(block).not.toContain("opacity: 1 !important");
+  });
+
+  it("turns off the smooth scrolling set on html", () => {
+    // globals.css sets `scroll-behavior: smooth` on html; that is motion too.
+    expect(css).toContain("scroll-behavior: smooth");
+    expect(block).toContain("scroll-behavior: auto !important");
+  });
+
+  it("exempts busy spinners so they do not freeze part-rotated", () => {
+    expect(block).toContain(":not(.animate-spin)");
+  });
+});


### PR DESCRIPTION
Nothing in the app looked at prefers-reduced-motion, so with the OS setting on the visualizers animated exactly as before. 106 files import framer-motion, and the CSS has its own transitions and smooth scrolling.

MotionProvider wraps the locale layout in MotionConfig reducedMotion="user". globals.css collapses transition and animation durations and turns off scroll-behavior: smooth. Nothing per-component.

Notes:

- "user" not "always", and durations collapse rather than animation: none. There are 441 initial={{ opacity: 0 }} entrances in this tree, so anything that stops opacity reaching 1 leaves content invisible. Fades still run, only the movement goes.
- .animate-spin is exempt. A spinner frozen part-rotated looks broken. 27 places use it.
- framer-motion reads the preference at mount, so an OS toggle applies on the next page load. The CSS half is live either way.
- Play All on the hub is unchanged, it only runs when pressed.

Checked against main with the preference emulated. On main it changes nothing, framer-motion defaults to "never" and there was no media query. Here transforms settle and scrolling goes instant, with nothing left at opacity 0.

Stepped through seven visualizers in both modes with the same settle time - same number of steps, same text at every stage, no errors. That covers the 35 AnimatePresence mode="wait" instances, where a stalled exit would block the next step.

yarn build passes, jest 44 tests across 8 suites, tsc and eslint clean.
