### PR TITLE
fix: derive MDX heading anchors from inline text

### DIFF
--- a/src/components/MdxComponents/MdxComponent.tsx
+++ b/src/components/MdxComponents/MdxComponent.tsx
@@ -29,6 +29,16 @@ const slugify = (text: string): string => {
     .replace(/^-+|-+$/g, '');
 };
 
+const getHeadingText = (children: React.ReactNode): string => {
+  return React.Children.toArray(children)
+    .map((child) =>
+      React.isValidElement<{ children?: React.ReactNode }>(child)
+        ? getHeadingText(child.props.children)
+        : child,
+    )
+    .join("");
+};
+
 const MdxComponents = {
   // TOC LINKS — underline on hover only (no dashed line)
   a: (props: HTMLProps<HTMLAnchorElement>): JSX.Element => {
@@ -77,17 +87,17 @@ const MdxComponents = {
 
   // Headings with IDs
   h1: (props: HTMLProps<HTMLHeadingElement>): JSX.Element => {
-    const text = React.Children.toArray(props.children).join('').trim();
+    const text = getHeadingText(props.children).trim();
     const id = slugify(text);
     return <h1 id={id} className="text-4xl font-bold my-6 scroll-mt-20" {...props} />;
   },
   h2: (props: HTMLProps<HTMLHeadingElement>): JSX.Element => {
-    const text = React.Children.toArray(props.children).join('').trim();
+    const text = getHeadingText(props.children).trim();
     const id = slugify(text);
     return <h2 id={id} className="text-3xl font-bold my-6 scroll-mt-20" {...props} />;
   },
   h3: (props: HTMLProps<HTMLHeadingElement>): JSX.Element => {
-    const text = React.Children.toArray(props.children).join('').trim();
+    const text = getHeadingText(props.children).trim();
     const id = slugify(text);
     return <h3 id={id} className="text-2xl font-bold my-5 scroll-mt-20" {...props} />;
   },

--- a/src/lib/__tests__/mdxHeadings.test.tsx
+++ b/src/lib/__tests__/mdxHeadings.test.tsx
@@ -1,0 +1,104 @@
+import React, { ComponentType, HTMLProps, ReactNode } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import MdxComponents from "@/components/MdxComponents/MdxComponent";
+
+// Heading tests do not need the routing, content-fetching or video runtimes.
+jest.mock("@/i18n/navigation", () => ({ Link: () => null }));
+jest.mock("@/lib/helpers", () => ({
+  transformGithubFilePathToWikiLink: jest.fn(),
+}));
+jest.mock("@/components/LiteYouTube", () => () => null);
+
+const fixtures: {
+  name: string;
+  children: ReactNode;
+  text: string;
+  id: string;
+}[] = [
+  {
+    name: "emphasis from the Italian Raspberry Pi guide",
+    children: ["Installazione di ", <em key="zcashd">zcashd</em>],
+    text: "Installazione di zcashd",
+    id: "installazione-di-zcashd",
+  },
+  {
+    name: "strong text",
+    children: ["The ", <strong key="network">Zcash Network</strong>],
+    text: "The Zcash Network",
+    id: "the-zcash-network",
+  },
+  {
+    name: "inline code",
+    children: ["Using ", <code key="zcashd">zcashd</code>],
+    text: "Using zcashd",
+    id: "using-zcashd",
+  },
+  {
+    name: "nested inline elements and fragments",
+    children: (
+      <>
+        Run <strong><em>zcashd</em></strong>
+        <> on <code>Raspberry Pi</code> {4}</>
+      </>
+    ),
+    text: "Run zcashd on Raspberry Pi 4",
+    id: "run-zcashd-on-raspberry-pi-4",
+  },
+  {
+    name: "existing plain-text punctuation rules",
+    children: " Zcash (Mainnet) + test_net ",
+    text: "Zcash (Mainnet) + test_net",
+    id: "zcash-mainnet-and-test-net",
+  },
+  {
+    name: "numbers including zero and empty nodes",
+    children: ["Section ", 0, null, false, undefined, " + ", 2],
+    text: "Section 0 + 2",
+    id: "section-0-and-2",
+  },
+  {
+    name: "bigint text",
+    children: ["Block ", BigInt("9007199254740993")],
+    text: "Block 9007199254740993",
+    id: "block-9007199254740993",
+  },
+];
+
+describe.each(["h1", "h2", "h3"] as const)("MDX %s anchors", (tag) => {
+  const Heading = MdxComponents[tag] as ComponentType<HTMLProps<HTMLHeadingElement>>;
+
+  it.each(fixtures)("uses heading text for $name", ({ children, text, id }) => {
+    render(<Heading>{children}</Heading>);
+
+    const heading = screen.getByRole("heading", { name: text });
+    expect(heading.tagName.toLowerCase()).toBe(tag);
+    expect(heading).toHaveAttribute("id", id);
+    expect(heading).toHaveTextContent(text);
+  });
+
+  it.each(["custom-anchor", ""])("preserves an explicit id %j", (id) => {
+    render(<Heading id={id}>Using <em>zcashd</em></Heading>);
+
+    expect(screen.getByRole("heading")).toHaveAttribute("id", id);
+  });
+});
+
+it("lets a table-of-contents link find and scroll to an emphasized heading", () => {
+  const Heading = MdxComponents.h3 as ComponentType<HTMLProps<HTMLHeadingElement>>;
+  const Anchor = MdxComponents.a as ComponentType<HTMLProps<HTMLAnchorElement>>;
+  render(
+    <>
+      <Anchor href="#installazione-di-zcashd">Installazione</Anchor>
+      <Heading>Installazione di <em>zcashd</em></Heading>
+    </>,
+  );
+  const heading = screen.getByRole("heading", { name: "Installazione di zcashd" });
+  const link = screen.getByRole("link", { name: "Installazione" });
+  const scrollIntoView = jest.fn();
+  heading.scrollIntoView = scrollIntoView;
+
+  expect(document.getElementById(link.getAttribute("href")!.slice(1))).toBe(heading);
+  fireEvent.click(link);
+
+  expect(scrollIntoView).toHaveBeenCalledWith({ behavior: "smooth", block: "start" });
+});


### PR DESCRIPTION
Formatted MDX headings currently put `object-object` in their IDs, so a table-of-contents link such as `#installazione-di-zcashd` cannot find `Installazione di *zcashd*`. Collect text from inline elements and fragments before applying the existing slug rules for h1–h3, while preserving explicit IDs and heading markup.

Validation: the new focused Jest suite failed 13 of 28 cases on main and passes all 28 with this change. It covers emphasis, strong text, inline code, nested fragments, plain text, numbers/bigint, explicit IDs and TOC scrolling. The suite is under `src/lib`, which the existing unit-test workflow already runs. No full app build was run.

AI-assisted implementation and validation.

Zcash unified receiving address:

`u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
