### PR TITLE
fix(donation): report clipboard results accurately

### DIFF
--- a/src/components/Donation/Donation.tsx
+++ b/src/components/Donation/Donation.tsx
@@ -6,6 +6,7 @@ import PenumbraWalletConnect from "../Penumbra/PenumbraWalletConnect";
 import "./donation.css";
 import { BsQrCodeScan } from "react-icons/bs";
 import { MdOutlineCopyAll } from "react-icons/md";
+import useClipboardFeedback from "@/hooks/useClipboardFeedback";
 
 type Token = "zcash" | "penumbra" | "ycash" | "namada" | "dash";
 type Symbol = "zec" | "um" | "yec" | "nam" | "dash";
@@ -24,7 +25,6 @@ const DonationComp = () => {
   const [imgLogo, setImgLogo] = useState(images.zcash);
   const [imgFade, setImgFade] = useState(false);
   const [isPenumbraVisible, setIsPenumbraVisible] = useState(false);
-  const [copied, setCopied] = useState(false);
 
   const zcashAddress =
     "u1rl2zw85dmjc8m4dmqvtstcyvdjn23n0ad53u5533c97affg9jq208du0vf787vfx4vkd6cd0ma4pxkkuc6xe6ue4dlgjvn9dhzacgk9peejwxdn0ksw3v3yf0dy47znruqftfqgf6xpuelle29g2qxquudxsnnen3dvdx8az6w3tggalc4pla3n4jcs8vf4h29ach3zd8enxulush89";
@@ -57,7 +57,12 @@ const DonationComp = () => {
     }
   };
 
+  const { copy, status, isCopying, reset } = useClipboardFeedback(
+    getDonationAddress()
+  );
+
   const handleOnClick = (tokenName: Token) => {
+    reset();
     setImgFade(true);
     let tokenSymbol: Symbol;
 
@@ -84,13 +89,6 @@ const DonationComp = () => {
       setImgLogo(images[tokenName]);
       setImgFade(false);
     }, 400);
-  };
-
-  const handleCopy = (text: string) => {
-    if (!text) return;
-    navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
   };
 
   const currencies: { id: Token; label: string; logo: string }[] = [
@@ -164,26 +162,47 @@ const DonationComp = () => {
         <div className="w-full relative">
           <div className="flex items-stretch gap-2">
             <div className="flex-1 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl px-4 py-3.5 shadow-sm overflow-hidden">
-              <p className="text-[13px] font-mono text-gray-800 dark:text-gray-200 break-all leading-relaxed select-all">
-                {getDonationAddress() || "Address coming soon…"}
-              </p>
+              {status === "error" ? (
+                <textarea
+                  aria-label="Donation address"
+                  readOnly
+                  value={getDonationAddress()}
+                  rows={4}
+                  onFocus={(event) => event.currentTarget.select()}
+                  className="block w-full bg-transparent text-[13px] font-mono text-gray-800 dark:text-gray-200 leading-relaxed"
+                />
+              ) : (
+                <p className="text-[13px] font-mono text-gray-800 dark:text-gray-200 break-all leading-relaxed select-all">
+                  {getDonationAddress() || "Address coming soon…"}
+                </p>
+              )}
             </div>
 
             <button
-              onClick={() => handleCopy(getDonationAddress())}
-              disabled={!getDonationAddress()}
+              type="button"
+              onClick={copy}
+              disabled={!getDonationAddress() || isCopying || imgFade}
               className="shrink-0 w-12 rounded-xl bg-[#1984c7] hover:bg-[#1573b0] disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center transition-colors shadow-sm"
               title="Copy address"
+              aria-label="Copy address"
             >
               <MdOutlineCopyAll color="white" size={20} />
             </button>
           </div>
 
-          {copied && (
-            <div className="absolute -bottom-10 left-1/2 -translate-x-1/2 bg-emerald-500 text-white text-xs font-medium px-3 py-1.5 rounded-full shadow-md animate-fade-in-out whitespace-nowrap">
-              Copied to clipboard
-            </div>
-          )}
+          <p
+            role="status"
+            aria-live="polite"
+            className="min-h-5 mt-2 text-center text-sm text-gray-700 dark:text-gray-300"
+          >
+            {isCopying
+              ? "Copying…"
+              : status === "copied"
+                ? "Copied to clipboard"
+                : status === "error"
+                  ? "Could not copy. Select and copy the address manually."
+                  : ""}
+          </p>
         </div>
       </div>
 

--- a/src/components/ZcashUAZArt.tsx
+++ b/src/components/ZcashUAZArt.tsx
@@ -1,11 +1,9 @@
 'use client';
 
-import { useState } from 'react';
 import QRCode from 'qrcode.react';
+import useClipboardFeedback from '@/hooks/useClipboardFeedback';
 
 export default function ZcashUAZArt() {
-  const [copied, setCopied] = useState(false);
-
   const ua = "u1rl2zw85dmjc8m4dmqvtstcyvdjn23n0ad53u5533c97affg9jq208du0vf787vfx4vkd6cd0ma4pxkkuc6xe6ue4dlgjvn9dhzacgk9peejwxdn0ksw3v3yf0dy47znruqftfqgf6xpuelle29g2qxquudxsnnen3dvdx8az6w3tggalc4pla3n4jcs8vf4h29ach3zd8enxulush89";
   const zArt = 
   `   u1rl2zw85dmjc8m4dmqvtstcyvdjn23n0ad53u
@@ -28,11 +26,7 @@ export default function ZcashUAZArt() {
       gf6xpuelle29g2qxquudxsnnen3dvdx8az6w3t
       ggalc4pla3n4jcs8vf4h29ach3zd8enxulush89`;
 
-  const copyUA = () => {
-    navigator.clipboard.writeText(ua);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
+  const { copy, status, isCopying } = useClipboardFeedback(ua);
 
   return (
     <div style={{ textAlign: 'center', margin: '50px 0' }}>
@@ -82,7 +76,9 @@ export default function ZcashUAZArt() {
 
       {/* Copy button below the entire box */}
       <button
-        onClick={copyUA}
+        type="button"
+        onClick={copy}
+        disabled={isCopying}
         style={{
           display: 'block',
 	  margin: '35px auto 0',
@@ -93,11 +89,37 @@ export default function ZcashUAZArt() {
           border: 'none',
           borderRadius: '12px',
           fontWeight: 'bold',
-          cursor: 'pointer'
+          cursor: isCopying ? 'wait' : 'pointer',
+          opacity: isCopying ? 0.6 : 1
         }}
       >
-        {copied ? '✅ Copied!' : '📋 Copy Full Unified Address'}
+        {isCopying
+          ? 'Copying…'
+          : status === 'copied'
+            ? '✅ Copied!'
+            : '📋 Copy Full Unified Address'}
       </button>
+      <p role="status" aria-live="polite" style={{ minHeight: '1.5em', marginTop: '12px' }}>
+        {isCopying
+          ? 'Copying…'
+          : status === 'copied'
+            ? 'Copied to clipboard'
+            : status === 'error'
+              ? 'Could not copy. Select and copy the address manually.'
+              : ''}
+      </p>
+      {status === 'error' && (
+        <label style={{ display: 'block', maxWidth: '400px', margin: '0 auto' }}>
+          Full unified address
+          <textarea
+            readOnly
+            value={ua}
+            rows={6}
+            onFocus={(event) => event.currentTarget.select()}
+            style={{ display: 'block', width: '100%', marginTop: '8px', padding: '8px', fontFamily: 'monospace', color: '#111', background: '#fff' }}
+          />
+        </label>
+      )}
     </div>
   );
 }

--- a/src/hooks/useClipboardFeedback.ts
+++ b/src/hooks/useClipboardFeedback.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export default function useClipboardFeedback(text: string) {
+  const [status, setStatus] = useState<"idle" | "copied" | "error">("idle");
+  const [isCopying, setIsCopying] = useState(false);
+  const mounted = useRef(false);
+  const inFlight = useRef(false);
+  const attempt = useRef(0);
+  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timer.current !== null) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+  }, []);
+
+  const reset = useCallback(() => {
+    // Invalidate feedback without allowing a second, overlapping clipboard write.
+    attempt.current += 1;
+    clearTimer();
+    setStatus("idle");
+  }, [clearTimer]);
+
+  useEffect(() => {
+    mounted.current = true;
+    reset();
+    return () => {
+      mounted.current = false;
+      attempt.current += 1;
+      clearTimer();
+    };
+  }, [text, reset, clearTimer]);
+
+  const copy = useCallback(async () => {
+    if (!text || inFlight.current) return;
+
+    reset();
+    const currentAttempt = attempt.current;
+    inFlight.current = true;
+    setIsCopying(true);
+
+    try {
+      await navigator.clipboard.writeText(text);
+      if (!mounted.current || currentAttempt !== attempt.current) return;
+      setStatus("copied");
+      timer.current = setTimeout(() => {
+        timer.current = null;
+        setStatus("idle");
+      }, 2000);
+    } catch {
+      if (mounted.current && currentAttempt === attempt.current) {
+        setStatus("error");
+      }
+    } finally {
+      inFlight.current = false;
+      if (mounted.current) setIsCopying(false);
+    }
+  }, [text, reset]);
+
+  return { copy, status, isCopying, reset };
+}

--- a/src/lib/__tests__/donationCopy.test.tsx
+++ b/src/lib/__tests__/donationCopy.test.tsx
@@ -1,0 +1,233 @@
+import React from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DonationComp from "@/components/Donation/Donation";
+import ZcashUAZArt from "@/components/ZcashUAZArt";
+import DonationClientWrapper from "@/components/DonationClientWrapper";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ alt }: { alt: string }) => <span role="img" aria-label={alt} />,
+}));
+jest.mock("qrcode.react", () => ({
+  __esModule: true,
+  default: ({ value }: { value: string }) => (
+    <div data-testid="donation-qr" data-address={value} />
+  ),
+}), { virtual: true });
+jest.mock("react-icons/bs", () => ({ BsQrCodeScan: () => null }), { virtual: true });
+jest.mock("react-icons/md", () => ({ MdOutlineCopyAll: () => null }), { virtual: true });
+jest.mock("@/components/Penumbra/PenumbraWalletConnect", () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+const zcashAddress =
+  "u1rl2zw85dmjc8m4dmqvtstcyvdjn23n0ad53u5533c97affg9jq208du0vf787vfx4vkd6cd0ma4pxkkuc6xe6ue4dlgjvn9dhzacgk9peejwxdn0ksw3v3yf0dy47znruqftfqgf6xpuelle29g2qxquudxsnnen3dvdx8az6w3tggalc4pla3n4jcs8vf4h29ach3zd8enxulush89";
+const ycashAddress =
+  "ys1t2e77wawylp8zky7wq3gzky2j4w6rpgd8632vmvqqj370thgpls8t973qutj4gn5wsc3qmcy56y";
+const failureMessage = "Could not copy. Select and copy the address manually.";
+const originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+function deferredWrite() {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function setupClipboard() {
+  const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+  const writeText = jest.fn<Promise<void>, [string]>().mockResolvedValue(undefined);
+  Object.defineProperty(navigator, "clipboard", {
+    configurable: true,
+    value: { writeText },
+  });
+  return { user, writeText };
+}
+
+async function click(user: ReturnType<typeof userEvent.setup>, element: Element) {
+  await user.click(element);
+  // Flush promise-driven updates without advancing the feedback clock.
+  await act(async () => {
+    await jest.advanceTimersByTimeAsync(0);
+  });
+}
+
+beforeEach(() => jest.useFakeTimers());
+
+afterEach(() => {
+  cleanup();
+  jest.clearAllTimers();
+  jest.useRealTimers();
+  if (originalClipboard) {
+    Object.defineProperty(navigator, "clipboard", originalClipboard);
+  } else {
+    Reflect.deleteProperty(navigator, "clipboard");
+  }
+});
+
+const views = [
+  { name: "v1", Component: DonationComp, copyName: /^Copy address$/, addressName: "Donation address" },
+  { name: "v0", Component: ZcashUAZArt, copyName: /Copy Full Unified Address/, addressName: "Full unified address" },
+];
+
+describe.each(views)("$name donation copy", ({ name, Component, copyName, addressName }) => {
+  it("waits for clipboard completion and prevents duplicate pending writes", async () => {
+    const { user, writeText } = setupClipboard();
+    const pending = deferredWrite();
+    writeText.mockReturnValueOnce(pending.promise);
+    render(<Component />);
+    const button = screen.getByRole("button", { name: copyName });
+    expect(screen.getByTestId("donation-qr")).toHaveAttribute("data-address", zcashAddress);
+    if (name === "v1") expect(screen.getByText(zcashAddress)).toBeInTheDocument();
+
+    await click(user, button);
+    expect(screen.queryByText(/Copied to clipboard|✅ Copied!/)).not.toBeInTheDocument();
+    expect(button).toBeDisabled();
+    expect(screen.getByRole("status")).toHaveTextContent("Copying…");
+    await click(user, button);
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith(zcashAddress);
+
+    await act(async () => pending.resolve());
+    expect(screen.getByRole("status")).toHaveTextContent("Copied to clipboard");
+    expect(button).toBeEnabled();
+  });
+
+  it.each(["rejected", "unavailable"])("provides keyboard manual copying when the API is %s", async (mode) => {
+    const { user, writeText } = setupClipboard();
+    if (mode === "rejected") {
+      writeText.mockRejectedValueOnce(new Error("Clipboard permission denied"));
+    } else {
+      Object.defineProperty(navigator, "clipboard", { configurable: true, value: undefined });
+    }
+    render(<Component />);
+    const button = screen.getByRole("button", { name: copyName });
+    const status = screen.getByRole("status");
+    expect(status).toBeEmptyDOMElement();
+
+    await click(user, button);
+
+    expect(status).toHaveTextContent(failureMessage);
+    expect(status).not.toHaveTextContent(/Copied to clipboard/);
+    const address = screen.getByRole("textbox", { name: addressName }) as HTMLTextAreaElement;
+    expect(address).toHaveAttribute("readonly");
+    expect(address).toHaveValue(zcashAddress);
+    await user.tab({ shift: name === "v1" });
+    expect(address).toHaveFocus();
+    expect(address.selectionStart).toBe(0);
+    expect(address.selectionEnd).toBe(zcashAddress.length);
+    expect(writeText).toHaveBeenCalledTimes(mode === "rejected" ? 1 : 0);
+
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    await click(user, button);
+    expect(status).toHaveTextContent("Copied to clipboard");
+    expect(screen.queryByRole("textbox", { name: addressName })).not.toBeInTheDocument();
+  });
+
+  it("gives repeated successful copies a fresh feedback duration", async () => {
+    const { user, writeText } = setupClipboard();
+    render(<Component />);
+    const button = screen.getByRole("button", { name: copyName });
+    await click(user, button);
+    act(() => jest.advanceTimersByTime(1500));
+    await click(user, button);
+
+    act(() => jest.advanceTimersByTime(500));
+    expect(screen.getByRole("status")).toHaveTextContent("Copied to clipboard");
+    act(() => jest.advanceTimersByTime(1499));
+    expect(screen.getByRole("status")).toHaveTextContent("Copied to clipboard");
+    act(() => jest.advanceTimersByTime(1));
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+    expect(writeText).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears the feedback timer when unmounted", async () => {
+    const { user } = setupClipboard();
+    const { unmount } = render(<Component />);
+    await click(user, screen.getByRole("button", { name: copyName }));
+    expect(screen.getByRole("status")).toHaveTextContent("Copied to clipboard");
+    const timersBeforeUnmount = jest.getTimerCount();
+    expect(timersBeforeUnmount).toBeGreaterThan(0);
+
+    unmount();
+
+    expect(jest.getTimerCount()).toBe(timersBeforeUnmount - 1);
+  });
+});
+
+describe("donation copy navigation", () => {
+  it("clears previous feedback and blocks copying during the currency transition", async () => {
+    const { user, writeText } = setupClipboard();
+    render(<DonationComp />);
+    const button = screen.getByRole("button", { name: "Copy address" });
+    await click(user, button);
+    expect(screen.getByRole("status")).toHaveTextContent("Copied to clipboard");
+
+    await click(user, screen.getByRole("button", { name: /Ycash/ }));
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+    expect(button).toBeDisabled();
+    await click(user, button);
+    act(() => jest.advanceTimersByTime(399));
+    expect(button).toBeDisabled();
+    expect(writeText).toHaveBeenCalledTimes(1);
+    act(() => jest.advanceTimersByTime(1));
+
+    expect(button).toBeEnabled();
+    expect(screen.getByText(ycashAddress)).toBeInTheDocument();
+    expect(screen.getByTestId("donation-qr")).toHaveAttribute("data-address", ycashAddress);
+    await click(user, button);
+    expect(writeText).toHaveBeenLastCalledWith(ycashAddress);
+  });
+
+  it.each(["resolved", "rejected"])("ignores a %s old copy after changing currency", async (outcome) => {
+    const { user, writeText } = setupClipboard();
+    const pending = deferredWrite();
+    writeText.mockReturnValueOnce(pending.promise);
+    render(<DonationComp />);
+    const button = screen.getByRole("button", { name: "Copy address" });
+    await click(user, button);
+    await click(user, screen.getByRole("button", { name: /Ycash/ }));
+    act(() => jest.advanceTimersByTime(400));
+    expect(screen.getByText(ycashAddress)).toBeInTheDocument();
+    expect(button).toBeDisabled();
+    await click(user, button);
+    expect(writeText).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      if (outcome === "resolved") pending.resolve();
+      else pending.reject(new Error("Clipboard permission denied"));
+    });
+
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+    expect(button).toBeEnabled();
+    await click(user, button);
+    expect(writeText).toHaveBeenLastCalledWith(ycashAddress);
+    expect(screen.getByRole("status")).toHaveTextContent("Copied to clipboard");
+  });
+
+  it("keeps a newly mounted donation view neutral after the old copy rejects", async () => {
+    const { user, writeText } = setupClipboard();
+    const pending = deferredWrite();
+    writeText.mockReturnValueOnce(pending.promise);
+    render(<DonationClientWrapper />);
+    await click(user, screen.getByRole("button", { name: "Copy address" }));
+    await click(user, screen.getByRole("tab", { name: "v0" }));
+    const button = screen.getByRole("button", { name: /Copy Full Unified Address/ });
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+
+    await act(async () => pending.reject(new Error("Clipboard permission denied")));
+
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
+    expect(button).toBeEnabled();
+    expect(screen.queryByRole("textbox", { name: "Full unified address" })).not.toBeInTheDocument();
+    await click(user, button);
+    expect(writeText).toHaveBeenCalledTimes(2);
+    expect(writeText).toHaveBeenLastCalledWith(zcashAddress);
+    expect(screen.getByRole("status")).toHaveTextContent("Copied to clipboard");
+  });
+});


### PR DESCRIPTION
Both donation views reported a successful copy before the clipboard promise resolved. If access was denied or unavailable, users still saw success or received no usable fallback.

This waits for a successful clipboard write, announces pending/success/failure status, and offers a labelled, keyboard-selectable full address when copying fails. Repeated writes are blocked while one is pending. Changing currency clears the old feedback and disables copying during the existing 400 ms transition; late results from an old address or unmounted view are ignored. A native clipboard write already in progress cannot itself be canceled.

Donation address literals, QR values and currency selection logic are unchanged.

Validation:
- 14 focused behavior tests pass. The two pending-copy cases both fail against unchanged source because success appears before clipboard completion; the other 12 cases were not run against the baseline.
- Tests use the actual donation components, view wrapper and feedback hook. Clipboard promises are controlled; QR rendering, images, icons and the unrelated Penumbra connector are mocked.
- Run with `node node_modules/jest/bin/jest.js src/lib/__tests__/donationCopy.test.tsx --ci --runInBand`.
- The new feedback hook passes a focused strict TypeScript check. Whitespace validation passes. No full app build, whole-project typecheck or live-browser visual check was run.

Prepared and independently reviewed with AI assistance. Local checks use the existing project lockfile; project dependencies and configuration are unchanged.

Unified receiving address:

`u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
