### PR TITLE
fix(grants): keep filters available for empty results

### DIFF
--- a/src/components/ZipsGrants/GrantList.tsx
+++ b/src/components/ZipsGrants/GrantList.tsx
@@ -127,13 +127,7 @@ export function GrantList(props: Props) {
         </div>
       )}
 
-      {search !== "" && filteredGrants.length === 0 && !props.isLoading && (
-        <p className="text-center py-8 text-muted-foreground text-sm">
-          Unable to fetch grants!
-        </p>
-      )}
-
-      {filteredGrants.length > 0 && (
+      {props.grants.length > 0 && (
         <div className="my-8">
           <div className="flex flex-row gap-2 flex-wrap mt-3">
             {[...CATEGORY_FILTER, "All"].sort().map((cf, i) => (
@@ -158,9 +152,11 @@ export function GrantList(props: Props) {
         </div>
       </div>
 
-      {search !== "" && filteredGrants.length === 0 && !props.isLoading && (
+      {filteredGrants.length === 0 && !props.isLoading && !props.error && (
         <p className="text-center py-8 text-muted-foreground text-sm">
-          No Grant(s) match your search!
+          {props.grants.length === 0
+            ? "No grants available."
+            : "No grants match your search or filters."}
         </p>
       )}
     </section>

--- a/src/lib/__tests__/grantList.test.tsx
+++ b/src/lib/__tests__/grantList.test.tsx
@@ -1,0 +1,134 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GrantList } from "@/components/ZipsGrants/GrantList";
+import { Grant } from "@/types/grants";
+
+const grants: Grant[] = [
+  {
+    id: "alpha",
+    project: "Alpha education project",
+    url: "https://example.com/alpha",
+    grantee: "Alpha team",
+    category: "Education",
+    reportingFrequency: null,
+    status: "Open",
+    milestones: [],
+    summary: {
+      totalMilestones: 0,
+      totalAmountUSD: 0,
+      totalUsdDisbursed: 0,
+      totalZecDisbursed: 0,
+      completedPercent: 0,
+      completedMilestones: 0,
+    },
+  },
+  {
+    id: "beta",
+    project: "Beta infrastructure project",
+    url: "https://example.com/beta",
+    grantee: "Beta team",
+    category: "Infrastructure",
+    reportingFrequency: null,
+    status: "Completed",
+    milestones: [],
+    summary: {
+      totalMilestones: 0,
+      totalAmountUSD: 0,
+      totalUsdDisbursed: 0,
+      totalZecDisbursed: 0,
+      completedPercent: 0,
+      completedMilestones: 0,
+    },
+  },
+];
+
+const defaultProps = {
+  grants,
+  error: "",
+  isLoading: false,
+  setError: jest.fn(),
+  setIsLoading: jest.fn(),
+};
+const noMatches = "No grants match your search or filters.";
+
+afterEach(cleanup);
+
+it("keeps category controls usable when a status change leaves no matches", async () => {
+  const user = userEvent.setup();
+  render(<GrantList {...defaultProps} />);
+
+  await user.click(screen.getByRole("button", { name: "Education" }));
+  await user.click(screen.getByRole("button", { name: "Completed" }));
+
+  expect(screen.queryByText(grants[0].project)).not.toBeInTheDocument();
+  expect(screen.queryByText(grants[1].project)).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Education" })).toBeVisible();
+  expect(screen.getAllByRole("button", { name: "All" })).toHaveLength(2);
+  expect(screen.getByText(noMatches)).toBeInTheDocument();
+
+  await user.click(screen.getByRole("button", { name: "Infrastructure" }));
+  expect(screen.getByText(grants[1].project)).toBeInTheDocument();
+  expect(screen.queryByText(grants[0].project)).not.toBeInTheDocument();
+  expect(screen.queryByText(noMatches)).not.toBeInTheDocument();
+});
+
+it("shows one accurate search-empty message and restores results after clearing", async () => {
+  const user = userEvent.setup();
+  render(<GrantList {...defaultProps} />);
+  const search = screen.getByPlaceholderText("Search grants...");
+
+  await user.type(search, "not a matching project");
+
+  expect(screen.queryByText(/Unable to fetch grants|Failed to load Grants/)).not.toBeInTheDocument();
+  expect(screen.getAllByText(noMatches)).toHaveLength(1);
+  expect(screen.getByRole("button", { name: "Education" })).toBeVisible();
+  expect(screen.queryByText(grants[0].project)).not.toBeInTheDocument();
+
+  await user.clear(search);
+  expect(screen.getByText(grants[0].project)).toBeInTheDocument();
+  expect(screen.getByText(grants[1].project)).toBeInTheDocument();
+  expect(screen.queryByText(noMatches)).not.toBeInTheDocument();
+});
+
+it("reports an empty loaded dataset without claiming a fetch failure", () => {
+  render(<GrantList {...defaultProps} grants={[]} />);
+
+  expect(screen.getByText("No grants available.")).toBeInTheDocument();
+  expect(screen.queryByText(noMatches)).not.toBeInTheDocument();
+  expect(screen.queryByText(/Unable to fetch grants|Failed to load Grants/)).not.toBeInTheDocument();
+});
+
+it("does not show empty-result feedback while loading", async () => {
+  const user = userEvent.setup();
+  render(<GrantList {...defaultProps} grants={[]} isLoading />);
+
+  await user.type(screen.getByPlaceholderText("Search grants..."), "missing");
+
+  expect(screen.getByText("Loading Grants...")).toBeInTheDocument();
+  expect(screen.queryByText(/No grants|No Grant\(s\)|Unable to fetch grants/)).not.toBeInTheDocument();
+});
+
+it("shows the supplied fetch error without adding no-match feedback", async () => {
+  const user = userEvent.setup();
+  render(<GrantList {...defaultProps} grants={[]} error="Request failed" />);
+
+  await user.type(screen.getByPlaceholderText("Search grants..."), "missing");
+
+  expect(screen.getByText("Failed to load Grants!")).toBeInTheDocument();
+  expect(screen.queryByText(/No grants|No Grant\(s\)|Unable to fetch grants/)).not.toBeInTheDocument();
+});
+
+it.each([
+  { isLoading: true, error: "", feedback: "Loading Grants..." },
+  { isLoading: false, error: "Request failed", feedback: "Failed to load Grants!" },
+])("preserves retained cards and filters alongside $feedback", ({ feedback, ...state }) => {
+  render(<GrantList {...defaultProps} {...state} />);
+
+  expect(screen.getByText(feedback)).toBeInTheDocument();
+  expect(screen.getByText(grants[0].project)).toBeInTheDocument();
+  expect(screen.getByText(grants[1].project)).toBeInTheDocument();
+  expect(screen.getByRole("button", { name: "Education" })).toBeVisible();
+  expect(screen.getByRole("button", { name: "Infrastructure" })).toBeVisible();
+  expect(screen.queryByText(noMatches)).not.toBeInTheDocument();
+});


### PR DESCRIPTION
Selecting a grant category and then a status with no matching records removes every category button, including its All reset. An unmatched search also shows both a fetch-failure message and a no-match message even when loading succeeded.

Keep category controls available whenever source grants exist, so visitors can recover by changing category directly. Show a single empty-state message, distinguishing an empty dataset from no matching filters and suppressing it during loading or an explicit error.

Validation:
- Seven focused React component tests pass using the actual child components. On unchanged main `6672c243`, four fail and three pass.
- Focused strict TypeScript check and `git diff --check` pass.
- Full application build and live-browser validation were not run.

AI-assisted implementation with Codex, with a separate Codex agent reviewing the source, tests and execution evidence.

Unified receiving address: `u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
