### PR TITLE
fix(search): preserve IME composition in navigation and 404 search

### DIFF
--- a/src/components/NotFoundSearch.tsx
+++ b/src/components/NotFoundSearch.tsx
@@ -65,6 +65,9 @@ export default function NotFoundSearch({ searchItems }: NotFoundSearchProps) {
   // Enter opens the top hit. SearchInput swallows form submission, so the key
   // has to be handled here or it would do nothing at all.
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    // Let IME candidate confirmation finish without opening a result.
+    if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+
     if (e.key !== "Enter") return;
     e.preventDefault();
     const first = list[0];

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -158,6 +158,9 @@ const SearchBar = ({
   );
 
   const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    // An IME can end composition before its final keydown (keyCode 229).
+    if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+
     if (e.key === "Escape") {
       return;
     }

--- a/src/lib/__tests__/notFoundSearchComposition.test.tsx
+++ b/src/lib/__tests__/notFoundSearchComposition.test.tsx
@@ -1,0 +1,85 @@
+import React from "react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import NotFoundSearch from "@/components/NotFoundSearch";
+
+const mockPush = jest.fn();
+
+jest.mock("@/i18n/navigation", () => ({
+  Link: (props: React.ComponentProps<"a">) => <a {...props} />,
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => "/guides/japanese-intro.html",
+}));
+
+jest.mock("@/context/LanguageContext", () => ({
+  useLanguage: () => ({ t: { common: {} } }),
+}));
+
+jest.mock("@/hooks/useDarkModeContext", () => ({
+  useDarkModeContext: () => ({ dark: false }),
+}));
+
+// Keep the application routing configuration while isolating the ESM factory.
+jest.mock("next-intl/routing", () => ({
+  defineRouting: (config: unknown) => config,
+}));
+
+const items = [
+  { name: "日本語 入門", desc: "Japanese introduction", url: "/guides/japanese-intro" },
+  { name: "日本語 道具", desc: "Japanese tools", url: "/guides/japanese-tools" },
+];
+
+function press(input: HTMLElement, init: KeyboardEventInit) {
+  const event = createEvent.keyDown(input, { ...init, bubbles: true, cancelable: true });
+  fireEvent(input, event);
+  return event;
+}
+
+beforeEach(() => mockPush.mockClear());
+
+describe.each(["suggestions", "search results"])("404 search IME with %s", (mode) => {
+  it.each(["composing", "final keyCode 229"])("leaves %s Enter to the IME and resumes normal navigation", (phase) => {
+    render(<NotFoundSearch searchItems={items} />);
+    const input = screen.getByRole("searchbox", { name: "Search" });
+    if (mode === "search results") {
+      fireEvent.change(input, { target: { value: "日本語" } });
+    }
+    expect(screen.getByRole("heading", {
+      name: mode === "suggestions" ? "Suggested pages" : "Results",
+    })).toBeInTheDocument();
+    const firstUrl = screen.getAllByRole("link")[0].getAttribute("href");
+    expect(firstUrl).toBe(items[0].url);
+    input.focus();
+    fireEvent.compositionStart(input);
+    if (phase === "final keyCode 229") {
+      fireEvent.compositionEnd(input, { data: "日本語" });
+    }
+    const event = press(input, {
+      key: "Enter",
+      isComposing: phase === "composing",
+      keyCode: phase === "final keyCode 229" ? 229 : 13,
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(event.defaultPrevented).toBe(false);
+    expect(input).toHaveFocus();
+    expect(input).toHaveValue(mode === "suggestions" ? "" : "日本語");
+
+    if (phase === "composing") {
+      fireEvent.compositionEnd(input, { data: "日本語" });
+    }
+    const ordinary = press(input, { key: "Enter", isComposing: false, keyCode: 13 });
+    expect(ordinary.defaultPrevented).toBe(true);
+    expect(mockPush).toHaveBeenCalledTimes(1);
+    expect(mockPush).toHaveBeenCalledWith(firstUrl);
+  });
+});
+
+it("keeps ordinary Enter from navigating when the query has no matches", () => {
+  render(<NotFoundSearch searchItems={items} />);
+  const input = screen.getByRole("searchbox", { name: "Search" });
+  fireEvent.change(input, { target: { value: "zzzzqqqqxxxx" } });
+  expect(screen.getByText("No matching pages")).toBeInTheDocument();
+  expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  press(input, { key: "Enter" });
+  expect(mockPush).not.toHaveBeenCalled();
+});

--- a/src/lib/__tests__/searchComposition.test.tsx
+++ b/src/lib/__tests__/searchComposition.test.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { createEvent, fireEvent, render, screen } from "@testing-library/react";
+import SearchBar from "@/components/SearchBar";
+
+const mockPush = jest.fn();
+
+jest.mock("@/i18n/navigation", () => ({
+  Link: React.forwardRef<HTMLAnchorElement, React.ComponentProps<"a">>(
+    function Link(props, ref) {
+      return <a {...props} ref={ref} />;
+    },
+  ),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("@/context/LanguageContext", () => ({
+  useLanguage: () => ({ t: { common: {} } }),
+}));
+
+jest.mock("@/hooks/useDarkModeContext", () => ({
+  useDarkModeContext: () => ({ dark: false }),
+}));
+
+jest.mock("@/components/AIAssistant", () => ({
+  __esModule: true,
+  default: ({ autoSendQuery, autoSendNonce }: {
+    autoSendQuery: string;
+    autoSendNonce: number;
+  }) => (
+    <div
+      data-testid="ai-panel"
+      data-query={autoSendQuery}
+      data-nonce={autoSendNonce}
+    />
+  ),
+}));
+
+const items = [
+  { name: "日本語 入門", desc: "Getting started", url: "/start-here/intro" },
+  { name: "日本語 道具", desc: "Using tools", url: "/guides/tools" },
+  { name: "日本語 資料", desc: "Further reading", url: "/guides/reference" },
+];
+
+async function openSearch() {
+  const onClose = jest.fn();
+  render(<SearchBar openSearch setOpenSearch={onClose} searchItems={items} />);
+  const input = await screen.findByRole("searchbox", { name: "Search" });
+  fireEvent.change(input, { target: { value: "日本語" } });
+  return { input, onClose };
+}
+
+function press(input: HTMLElement, init: KeyboardEventInit) {
+  const event = createEvent.keyDown(input, { ...init, bubbles: true, cancelable: true });
+  fireEvent(input, event);
+  return event;
+}
+
+function selectedLink() {
+  return screen.getAllByRole("link").find((link) => link.dataset.selected === "true");
+}
+
+beforeEach(() => {
+  mockPush.mockClear();
+});
+
+describe("SearchBar IME composition", () => {
+  it("leaves composing Enter to the IME, then opens the result after composition ends", async () => {
+    const { input, onClose } = await openSearch();
+    fireEvent.compositionStart(input);
+    const composing = press(input, { key: "Enter", isComposing: true });
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(composing.defaultPrevented).toBe(false);
+    expect(input).toHaveValue("日本語");
+
+    fireEvent.compositionEnd(input, { data: "日本語" });
+    const committed = press(input, { key: "Enter", isComposing: false });
+    expect(committed.defaultPrevented).toBe(true);
+    expect(mockPush).toHaveBeenCalledWith(items[0].url);
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+
+  it.each(["ArrowDown", "ArrowUp"])("does not change the selected result for composing %s", async (key) => {
+    const { input } = await openSearch();
+    press(input, { key: "ArrowDown" });
+    const selected = selectedLink();
+    expect(selected).toHaveAttribute("href", items[1].url);
+
+    fireEvent.compositionStart(input);
+    const event = press(input, { key, isComposing: true });
+
+    expect(selectedLink()).toBe(selected);
+    expect(event.defaultPrevented).toBe(false);
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it.each(["ctrlKey", "metaKey"] as const)("does not send an AI query for composing %s+Enter", async (modifier) => {
+    const { input, onClose } = await openSearch();
+    fireEvent.compositionStart(input);
+    const event = press(input, { key: "Enter", [modifier]: true, isComposing: true });
+
+    expect(screen.getByTestId("ai-panel")).toHaveAttribute("data-nonce", "0");
+    expect(event.defaultPrevented).toBe(false);
+    expect(screen.getByRole("searchbox", { name: "Search" })).toBe(input);
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])("ignores the final keyCode 229 Enter when isComposing is already false (Ctrl: %s)", async (ctrlKey) => {
+    const { input, onClose } = await openSearch();
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { data: "日本語" });
+    const event = press(input, { key: "Enter", keyCode: 229, isComposing: false, ctrlKey });
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    expect(screen.getByTestId("ai-panel")).toHaveAttribute("data-nonce", "0");
+    expect(event.defaultPrevented).toBe(false);
+    expect(screen.getByRole("searchbox", { name: "Search" })).toBe(input);
+  });
+
+  it("preserves ordinary arrow selection and Enter navigation", async () => {
+    const { input, onClose } = await openSearch();
+    expect(press(input, { key: "ArrowDown" }).defaultPrevented).toBe(true);
+    press(input, { key: "ArrowDown" });
+    expect(selectedLink()).toHaveAttribute("href", items[2].url);
+    expect(press(input, { key: "ArrowUp" }).defaultPrevented).toBe(true);
+    expect(selectedLink()).toHaveAttribute("href", items[1].url);
+
+    press(input, { key: "Enter" });
+    expect(mockPush).toHaveBeenCalledWith(items[1].url);
+    expect(onClose).toHaveBeenCalledWith(false);
+  });
+
+  it.each(["ctrlKey", "metaKey"] as const)("preserves %s+Enter after composition ends", async (modifier) => {
+    const { input, onClose } = await openSearch();
+    fireEvent.compositionStart(input);
+    fireEvent.compositionEnd(input, { data: "日本語" });
+    const event = press(input, { key: "Enter", [modifier]: true, isComposing: false });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(screen.queryByRole("searchbox", { name: "Search" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("ai-panel")).toHaveAttribute("data-query", "日本語");
+    expect(screen.getByTestId("ai-panel")).toHaveAttribute("data-nonce", "1");
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Confirming text with an input method editor (IME) can trigger search shortcuts before the reader finishes a character. In the navigation search, Enter can open a result, arrows can move the selected link, and Ctrl/Cmd+Enter can switch to the AI panel. On the 404 page, Enter can open the first suggestion or search result.

Both key handlers now ignore events while the native keyboard event is composing, including the documented keyCode 229 case where compositionend precedes the final keydown. Normal shortcuts resume after composition ends. The production change is two small guards; matching, links, translations and the navigation menu retain their existing behavior.

The 404 extension builds on the recovery search introduced by @crackedsdev in #769 and the earlier 404 route work by @delegram-pixel in #729. It is part of this existing PR.

Validation:

- All 15 focused component tests pass: 10 navigation search tests and 5 404 search tests.
- The original navigation suite produced 7 failures and 3 passes against the original navigation handler. Against this PR's previously published head f30ed8b, the combined suite produces 4 failures and 11 passes: all four new 404 composition cases navigate prematurely, while the 10 existing navigation cases and the no-match case pass.
- The 404 cases cover both suggestions and typed Japanese results, composing Enter and the final keyCode 229 event, preserving focus/input and leaving the composition key unconsumed. They also check that the next normal Enter opens the first visible result and that a query with no matches does not navigate.
- Tests exercise the real search components, shared SearchInput, search/suggestion helpers, highlighting and icons; navigation tests also use real Headless UI. Routing, language/theme context and the unrelated AI panel are mocked. The 404 test retains the application routing configuration through an identity mock of next-intl's ESM factory. No AI requests are made.
- git diff --check passes. The tests use simulated native events in jsdom; no full application build, full typecheck or native OS IME/browser validation was performed. The focused local run used an external SSD dependency runtime.

Implemented with Codex assistance and independently reviewed by another AI agent.

Unified address for a discretionary tip:
u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq
