### PR TITLE
fix(treasury): use ZEC balances for allocation chart values

### DIFF
--- a/src/components/Charts/SheetTreasuryTab.tsx
+++ b/src/components/Charts/SheetTreasuryTab.tsx
@@ -176,7 +176,7 @@ function extractSections(data: unknown[]) {
 function fpfPieRows(fpf: FPFData) {
   return fpf.Category.map((name, i) => ({
     name,
-    value: fpf.Allocation[i] ?? fpf["Amount (ZEC)"][i] ?? 0,
+    value: fpf["Amount (ZEC)"][i] ?? 0,
   })).filter((r) => r.value > 0);
 }
 

--- a/src/components/__tests__/sheetTreasuryTab.test.tsx
+++ b/src/components/__tests__/sheetTreasuryTab.test.tsx
@@ -1,0 +1,55 @@
+import type { ReactElement } from "react";
+import { render, screen } from "@testing-library/react";
+import SheetTreasuryTab from "../Charts/SheetTreasuryTab";
+
+jest.mock("@/i18n/navigation", () => ({ Link: "a" }));
+
+// JSDOM has no layout measurements; give the real chart a fixed viewport.
+jest.mock("recharts", () => ({
+  ...jest.requireActual("recharts"),
+  ResponsiveContainer: ({ children }: { children: ReactElement }) =>
+    jest.requireActual("react").cloneElement(children, { width: 500, height: 280 }),
+}));
+
+const treasurySheet = {
+  table: {
+    cols: [],
+    rows: [
+      { c: [{ v: "FPF" }, null, null] },
+      { c: [{ v: "Category" }, null, { v: "Allocation" }] },
+      { c: [{ v: "Global Ambassador Provisioning" }, { v: 0 }, { v: "0.00%" }] },
+      { c: [{ v: "Hackathon" }, { v: 25 }, { v: "55.56%" }] },
+      { c: [{ v: "Community Proposals" }, { v: 10 }, { v: "22.22%" }] },
+      { c: [{ v: "Small Bounty Fund" }, { v: 10 }, { v: "22.22%" }] },
+    ],
+  },
+};
+
+describe("Treasury chart units", () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("shows ZEC balances in the chart and percentages only in the allocation column", async () => {
+    global.fetch = jest.fn(async (input) => {
+      if (String(input).startsWith("https://docs.google.com/spreadsheets/")) {
+        return { ok: true, text: async () => JSON.stringify(treasurySheet) };
+      }
+      if (String(input).startsWith("/api/prices/simple?")) {
+        return { ok: true, json: async () => ({ zcash: { usd: 521 } }) };
+      }
+      throw new Error(`Unexpected fetch: ${input}`);
+    }) as jest.Mock;
+
+    render(<SheetTreasuryTab />);
+
+    expect(await screen.findByText("25 ZEC")).toBeInTheDocument();
+    expect(screen.getAllByText("10 ZEC")).toHaveLength(2);
+    expect(screen.queryByText("55.56 ZEC")).not.toBeInTheDocument();
+    expect(screen.queryByText("22.22 ZEC")).not.toBeInTheDocument();
+    expect(screen.getByText("55.56%")).toBeInTheDocument();
+    expect(screen.getAllByText("22.22%")).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
The FPF allocation chart displays allocation percentages as ZEC amounts. In the current treasury sheet, the Hackathon row has an amount of 25 ZEC and an allocation of 55.56%, but the chart legend and tooltip show 55.56 ZEC. The two 10 ZEC rows similarly display 22.22 ZEC each.

Use the `Amount (ZEC)` column for chart values. The allocation percentage column in the table remains unchanged. No spreadsheet data or other treasury calculations are modified.

Validation: added a component regression that fails on the original implementation and checks the real sheet parser, chart legend and allocation table. All 131 Jest tests across 15 suites pass; focused ESLint and git diff checks pass. A separate review also reran the full Jest suite successfully. No full production build or browser visual check was run.

AI assistance was used for implementation and verification. Please consider this contribution under the published [approved development contribution program](https://github.com/ZecHub/zechub/blob/main/site/contribute/Contributing_Guide.md) and confirm eligibility and any reward amount. No award is assumed. My receiving-address compatibility question is recorded in https://github.com/ZecHub/zechub/pull/2051#issuecomment-5575794243.

Miroslav Strisko
