### PR TITLE
fix(gallery): support keyboard entry and lightbox focus

### DIFF
--- a/src/components/Gallery/Gallery.tsx
+++ b/src/components/Gallery/Gallery.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import Image from "next/image";
-import React, { useState, useEffect } from "react";
+import { Dialog, DialogPanel } from "@headlessui/react";
+import React, { useState, useRef } from "react";
 import styles from './Gallery.module.css';
 
 const Gallery: React.FC = () => {
   const galleryImages = Array.from({ length: 15 }, (_, i) => `/gallery/${i + 1}.png`);
 
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
   const selectedImage = selectedIndex !== null ? galleryImages[selectedIndex] : null;
 
   const closeModal = () => setSelectedIndex(null);
@@ -24,20 +26,6 @@ const Gallery: React.FC = () => {
     }
   };
 
-  // Keyboard shortcuts (Escape, ←, →)
-  useEffect(() => {
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeModal();
-      if (e.key === 'ArrowLeft') goToPrevious();
-      if (e.key === 'ArrowRight') goToNext();
-    };
-
-    if (selectedIndex !== null) {
-      document.addEventListener('keydown', handleKeyDown);
-    }
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [selectedIndex]);
-
   const downloadImage = (url: string, filename: string) => {
     const link = document.createElement('a');
     link.href = url;
@@ -52,12 +40,14 @@ const Gallery: React.FC = () => {
       <div className={styles.gallery}>
         <div className={styles.galleryContainer}>
           {galleryImages.map((src, index) => (
-            <div
+            <button
               key={index}
-              className={`${styles.imageContainer} cursor-pointer group`}
+              type="button"
+              aria-label={`Open Zcash gallery image ${index + 1}`}
+              className={`${styles.imageContainer} cursor-pointer group focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-500`}
               onClick={() => setSelectedIndex(index)}
             >
-              <div className="relative w-full aspect-[4/3] overflow-hidden rounded-xl">
+              <span className="relative block w-full aspect-[4/3] overflow-hidden rounded-xl">
                 <Image
                   src={src}
                   alt={`Zcash gallery image ${index + 1}`}
@@ -67,21 +57,36 @@ const Gallery: React.FC = () => {
                   priority={index < 4}
                   quality={85}
                 />
-              </div>
-            </div>
+              </span>
+            </button>
           ))}
         </div>
       </div>
 
       {/* Full-screen Lightbox Modal */}
       {selectedImage && selectedIndex !== null && (
-        <div
+        <Dialog
+          open
+          onClose={closeModal}
+          initialFocus={closeButtonRef}
+          aria-label="Zcash image gallery"
           className="fixed inset-0 bg-black/95 z-[200] flex items-center justify-center p-4 cursor-pointer"
-          onClick={closeModal}
+          onKeyDown={(e) => {
+            if (e.key === 'ArrowLeft') {
+              e.preventDefault();
+              goToPrevious();
+            } else if (e.key === 'ArrowRight') {
+              e.preventDefault();
+              goToNext();
+            }
+          }}
         >
-          <div className="relative w-full max-w-5xl" onClick={(e) => e.stopPropagation()}>
+          <DialogPanel className="relative w-full max-w-5xl">
             {/* Close button */}
             <button
+              ref={closeButtonRef}
+              type="button"
+              aria-label="Close image preview"
               onClick={closeModal}
               className="absolute -top-12 right-4 text-white text-5xl hover:text-amber-400 transition-colors"
             >
@@ -90,12 +95,16 @@ const Gallery: React.FC = () => {
 
             {/* Navigation arrows */}
             <button
+              type="button"
+              aria-label="Previous image"
               onClick={goToPrevious}
               className="absolute left-4 top-1/2 -translate-y-1/2 bg-black/70 hover:bg-black text-white text-5xl w-14 h-14 flex items-center justify-center rounded-full transition-all active:scale-95"
             >
               ←
             </button>
             <button
+              type="button"
+              aria-label="Next image"
               onClick={goToNext}
               className="absolute right-4 top-1/2 -translate-y-1/2 bg-black/70 hover:bg-black text-white text-5xl w-14 h-14 flex items-center justify-center rounded-full transition-all active:scale-95"
             >
@@ -114,6 +123,7 @@ const Gallery: React.FC = () => {
             {/* Download button + info */}
             <div className="mt-8 flex flex-col items-center gap-4">
               <button
+                type="button"
                 onClick={() => downloadImage(selectedImage, `zechub-gallery-${selectedIndex + 1}.png`)}
                 className="flex items-center gap-3 bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-black font-bold text-lg px-10 py-4 rounded-full transition-all shadow-lg active:scale-95"
               >
@@ -123,8 +133,8 @@ const Gallery: React.FC = () => {
                 Image {selectedIndex + 1} of 15 • Click outside or press ESC to close
               </p>
             </div>
-          </div>
-        </div>
+          </DialogPanel>
+        </Dialog>
       )}
     </>
   );

--- a/src/lib/__tests__/galleryKeyboard.test.tsx
+++ b/src/lib/__tests__/galleryKeyboard.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import Gallery from "@/components/Gallery/Gallery";
+
+jest.mock("next/image", () => ({
+  __esModule: true,
+  default: ({ src, alt }: { src: string; alt: string }) => <img src={src} alt={alt} />,
+}));
+
+describe("Gallery keyboard access", () => {
+  it.each(["{Enter}", " "])("opens a thumbnail with %s and restores focus after Escape", async (key) => {
+    const user = userEvent.setup();
+    render(<Gallery />);
+    await user.tab();
+    const thumbnail = screen.getByRole("button", { name: "Open Zcash gallery image 1" });
+    expect(thumbnail).toHaveFocus();
+
+    await user.keyboard(key);
+    const dialog = await screen.findByRole("dialog", { name: "Zcash image gallery" });
+    expect(within(dialog).getByAltText("Gallery image 1")).toBeInTheDocument();
+    await waitFor(() => expect(within(dialog).getByRole("button", { name: "Close image preview" })).toHaveFocus());
+
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(thumbnail).toHaveFocus());
+  });
+
+  it("keeps tab navigation inside the lightbox", async () => {
+    const user = userEvent.setup();
+    render(<><Gallery /><button>After gallery</button></>);
+    await user.click(screen.getByAltText("Zcash gallery image 4"));
+    const dialog = await screen.findByRole("dialog", { name: "Zcash image gallery" });
+    const close = within(dialog).getByRole("button", { name: "Close image preview" });
+    await waitFor(() => expect(close).toHaveFocus());
+
+    await user.tab({ shift: true });
+    expect(within(dialog).getByRole("button", { name: "Download" })).toHaveFocus();
+    await user.tab();
+    expect(close).toHaveFocus();
+    await user.tab();
+    expect(within(dialog).getByRole("button", { name: "Previous image" })).toHaveFocus();
+    await user.tab();
+    expect(within(dialog).getByRole("button", { name: "Next image" })).toHaveFocus();
+  });
+
+  it("wraps image navigation with the arrow keys while keeping focus in the lightbox", async () => {
+    const user = userEvent.setup();
+    render(<Gallery />);
+    await user.click(screen.getByAltText("Zcash gallery image 1"));
+    const dialog = await screen.findByRole("dialog", { name: "Zcash image gallery" });
+    const close = within(dialog).getByRole("button", { name: "Close image preview" });
+    await waitFor(() => expect(close).toHaveFocus());
+
+    await user.keyboard("{ArrowLeft}");
+    expect(within(dialog).getByAltText("Gallery image 15")).toBeInTheDocument();
+    await user.keyboard("{ArrowRight}");
+    expect(within(dialog).getByAltText("Gallery image 1")).toBeInTheDocument();
+    expect(close).toHaveFocus();
+  });
+
+  it("closes on a backdrop click and restores the selected thumbnail", async () => {
+    const user = userEvent.setup();
+    render(<Gallery />);
+    const thumbnail = screen.getByRole("button", { name: "Open Zcash gallery image 7" });
+    await user.click(thumbnail);
+    const dialog = await screen.findByRole("dialog", { name: "Zcash image gallery" });
+    await user.click(dialog);
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(thumbnail).toHaveFocus());
+  });
+
+  it("preserves pointer navigation, image clicks and the selected download", async () => {
+    const user = userEvent.setup();
+    let downloaded: { href: string; name: string } | undefined;
+    const click = jest.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (this: HTMLAnchorElement) {
+      downloaded = { href: this.getAttribute("href")!, name: this.download };
+    });
+    try {
+      render(<Gallery />);
+      await user.click(screen.getByAltText("Zcash gallery image 15"));
+      await user.click(screen.getByText("→"));
+      expect(screen.getByAltText("Gallery image 1")).toBeInTheDocument();
+      await user.click(screen.getByText("←"));
+      await user.click(screen.getByAltText("Gallery image 15"));
+      await user.click(screen.getByRole("button", { name: "Download" }));
+      expect(downloaded).toEqual({ href: "/gallery/15.png", name: "zechub-gallery-15.png" });
+      expect(screen.getByAltText("Gallery image 15")).toBeInTheDocument();
+      await user.click(screen.getByText("✕"));
+      await waitFor(() => expect(screen.queryByAltText("Gallery image 15")).not.toBeInTheDocument());
+    } finally {
+      click.mockRestore();
+    }
+  });
+
+  it("leaves arrow keys alone when the lightbox is closed", () => {
+    render(<Gallery />);
+    const event = new KeyboardEvent("keydown", { key: "ArrowRight", bubbles: true, cancelable: true });
+    fireEvent(document, event);
+    expect(event.defaultPrevented).toBe(false);
+    expect(screen.queryByAltText("Gallery image 1")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Gallery thumbnails cannot receive keyboard focus, so keyboard users cannot open an image preview. Use native thumbnail buttons and the existing Headless UI Dialog to support Enter/Space entry, focus containment, Escape dismissal and focus restoration. Label the icon controls and keep image navigation and download behavior intact.

Validation: seven focused component tests pass using the real Gallery and Headless UI components. The same tests against unchanged main fail five and pass two. They cover keyboard entry, focus movement/restoration, arrow-key wraparound, backdrop dismissal, pointer navigation and the selected download URL/filename. Next/Image is mocked; no full app build, browser visual check, screen-reader session or actual file download was run.

AI assistance: Codex prepared the implementation and tests; a separate AI review is recorded before publication.

Unified receiving address: `u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
