### PR TITLE
fix(wallets): make mobile filtering keyboard accessible

### DIFF
--- a/src/components/FilterToggle.tsx
+++ b/src/components/FilterToggle.tsx
@@ -44,7 +44,7 @@ const FilterToggle: React.FC<FilterToggleProps> = ({
                     }}
                   />
 
-                  <div className="w-8 h-4 bg-gray-200 dark:bg-gray-400 rounded-full peer-checked:bg-blue-500 transition-colors"></div>
+                  <div className="w-8 h-4 bg-gray-200 dark:bg-gray-400 rounded-full peer-checked:bg-blue-500 peer-focus-visible:ring-2 peer-focus-visible:ring-blue-600 peer-focus-visible:ring-offset-2 transition-colors"></div>
 
                   <div className="dot absolute left-[2px] top-[2px] w-3 h-3 bg-white rounded-full transition-transform peer-checked:translate-x-4"></div>
                 </div>

--- a/src/components/Wallet/WalletList.tsx
+++ b/src/components/Wallet/WalletList.tsx
@@ -1,5 +1,6 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
+import { Dialog, DialogPanel, DialogTitle } from "@headlessui/react";
 import WalletItem from "@/components/Wallet/WalletItem";
 import FilterToggle from "@/components/FilterToggle";
 import { useLanguage } from "@/context/LanguageContext";
@@ -35,6 +36,8 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
   const [error, setError] = useState<{ [key: string]: string }>({});
   const [success, setSuccess] = useState<{ [key: string]: string }>({});
   const [isFilterVisible, setIsFilterVisible] = useState(false);
+  const filterTriggerRef = useRef<HTMLButtonElement>(null);
+  const closeFilterRef = useRef<HTMLButtonElement>(null);
 
   const { t } = useLanguage();
   const filtersLabel = t?.wallets?.filters ?? "Filters";
@@ -177,7 +180,11 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
         <div className="wl-mobile-header">
           <span className="wl-mobile-title">{filtersLabel}</span>
           <button 
-            className="wl-btn" 
+            type="button"
+            ref={filterTriggerRef}
+            aria-haspopup="dialog"
+            aria-expanded={isFilterVisible}
+            className="wl-btn focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
             onClick={handleToggleFilter}
           >
             <span className="wl-btn-icon">Settings</span>
@@ -191,18 +198,21 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
         {/* Active filter chips */}
         {activeFilters.length > 0 && (
           <div className="wl-active-chips">
-            {activeFilters.map((item, i) => (
-              <span
-                key={i}
-                className="wl-chip"
-                onClick={() => {
-                  const [cat, val] = item.split(":");
-                  toggleFilter(cat, val);
+            {activeFilters.map((item) => (
+              <button
+                type="button"
+                key={item}
+                className="wl-chip focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+                onClick={(event) => {
+                  const neighbor = event.currentTarget.nextElementSibling ?? event.currentTarget.previousElementSibling;
+                  setActiveFilters((prev) => prev.filter((filter) => filter !== item));
+                  if (neighbor instanceof HTMLButtonElement) neighbor.focus();
+                  else filterTriggerRef.current?.focus();
                 }}
               >
                 {item.split(":")[1]}
-                <span className="wl-chip-x">Close</span>
-              </span>
+                <span className="wl-chip-x">{closeLabel}</span>
+              </button>
             ))}
           </div>
         )}
@@ -256,16 +266,22 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
 
         {/* Mobile drawer */}
         {isFilterVisible && (
-          <div className="wl-mobile-drawer fixed inset-0 z-50 bg-black/60 flex items-end">
-            <div 
+          <Dialog
+            open={isFilterVisible}
+            onClose={() => setIsFilterVisible(false)}
+            initialFocus={closeFilterRef}
+            className="wl-root wl-mobile-drawer fixed inset-0 z-50 bg-black/60 flex items-end"
+          >
+            <DialogPanel
               className="bg-white dark:bg-slate-900 w-full max-h-[85vh] rounded-t-3xl overflow-hidden shadow-xl"
-              onClick={(e) => e.stopPropagation()}
             >
               <div className="wl-drawer-header px-6 py-4 border-b flex items-center justify-between">
-                <span className="text-lg font-semibold">{filtersLabel}</span>
+                <DialogTitle as="span" className="text-lg font-semibold">{filtersLabel}</DialogTitle>
                 <button 
-                  className="wl-btn text-sm font-medium"
-                  onClick={handleToggleFilter}
+                  type="button"
+                  ref={closeFilterRef}
+                  className="wl-btn text-sm font-medium focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-2"
+                  onClick={() => setIsFilterVisible(false)}
                 >
                   {closeLabel}
                 </button>
@@ -279,8 +295,8 @@ const WalletList: React.FC<Props> = ({ allWallets }) => {
                   handleToggleFilter={handleToggleFilter}
                 />
               </div>
-            </div>
-          </div>
+            </DialogPanel>
+          </Dialog>
         )}
       </div>
     </>

--- a/src/lib/__tests__/walletFiltersKeyboard.test.tsx
+++ b/src/lib/__tests__/walletFiltersKeyboard.test.tsx
@@ -1,0 +1,136 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WalletList from "@/components/Wallet/WalletList";
+
+jest.mock("@/context/LanguageContext", () => ({ useLanguage: () => ({ t: {} }) }));
+jest.mock("@/components/Wallet/WalletItem", () => ({
+  __esModule: true,
+  default: ({ title }: { title: string }) => <h2>{title}</h2>,
+}));
+
+const wallets = [
+  { title: "Pocket wallet", devices: ["Mobile"], operatingSystem: ["Android"] },
+  { title: "Desk wallet", devices: ["Desktop"], operatingSystem: ["Linux"] },
+].map((wallet) => ({
+  ...wallet, url: "https://example.com", imageUrl: "/wallet.png", pools: ["Orchard"],
+  features: ["Shielded"], walletSupport: ["Unified"], syncSpeed: "", ironwood: "ready",
+}));
+
+function renderMobile() {
+  // Model the existing narrow-screen sidebar visibility; this is not a layout test.
+  return render(<><style>{".wl-sidebar { display: none; }"}</style><WalletList allWallets={wallets} /><button>After wallets</button></>);
+}
+
+describe("Wallet filtering keyboard access", () => {
+  const originalFetch = global.fetch;
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+  });
+  afterEach(() => { global.fetch = originalFetch; });
+
+  it.each(["{Enter}", " "])("opens with %s, focuses the panel and returns to the opener after Escape", async (key) => {
+    const user = userEvent.setup();
+    renderMobile();
+    await user.tab();
+    const opener = screen.getByRole("button", { name: /Show Navigation/ });
+    expect(opener).toHaveFocus();
+    await user.keyboard(key);
+    const dialog = await screen.findByRole("dialog", { name: "Filters" });
+    await waitFor(() => expect(within(dialog).getByRole("button", { name: "Close" })).toHaveFocus());
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(opener).toHaveFocus());
+  });
+
+  it("contains Tab navigation and selects a filter with Space without moving focus", async () => {
+    const user = userEvent.setup();
+    renderMobile();
+    await user.click(screen.getByRole("button", { name: /Show Navigation/ }));
+    const dialog = await screen.findByRole("dialog", { name: "Filters" });
+    const close = within(dialog).getByRole("button", { name: "Close" });
+    await waitFor(() => expect(close).toHaveFocus());
+    await user.tab({ shift: true });
+    expect(within(dialog).getByRole("checkbox", { name: "ready" })).toHaveFocus();
+    await user.tab();
+    expect(close).toHaveFocus();
+    await user.tab();
+    const desktop = within(dialog).getByRole("checkbox", { name: "Desktop" });
+    expect(desktop).toHaveFocus();
+    await user.keyboard(" ");
+    expect(desktop).toBeChecked();
+    expect(desktop).toHaveFocus();
+    await user.keyboard("{Escape}");
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    expect(screen.getByText("1 wallet")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Desk wallet" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Pocket wallet" })).not.toBeInTheDocument();
+  });
+
+  it.each(["{Enter}", " "])("removes the final chip with %s and restores the opener", async (key) => {
+    const user = userEvent.setup();
+    renderMobile();
+    const opener = screen.getByRole("button", { name: /Show Navigation/ });
+    await user.click(opener);
+    const drawer = document.querySelector(".wl-mobile-drawer") as HTMLElement;
+    await user.click(within(drawer).getByRole("checkbox", { name: "Mobile" }));
+    await user.click(within(drawer).getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(document.querySelector(".wl-mobile-drawer")).toBeNull());
+    opener.focus();
+    await user.tab();
+    const chip = screen.getByRole("button", { name: "Mobile Close" });
+    expect(chip).toHaveFocus();
+    await user.keyboard(key);
+    expect(screen.queryByRole("button", { name: "Mobile Close" })).not.toBeInTheDocument();
+    expect(screen.getByText("2 wallets")).toBeInTheDocument();
+    expect(opener).toHaveFocus();
+  });
+
+  it("moves focus to the next chip, then the previous chip when removing selected filters", async () => {
+    const user = userEvent.setup();
+    renderMobile();
+    await user.click(screen.getByRole("button", { name: /Show Navigation/ }));
+    const drawer = document.querySelector(".wl-mobile-drawer") as HTMLElement;
+    for (const name of ["Mobile", "Orchard", "Shielded"]) {
+      await user.click(within(drawer).getByRole("checkbox", { name }));
+    }
+    await user.click(within(drawer).getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(document.querySelector(".wl-mobile-drawer")).toBeNull());
+    await user.click(screen.getByRole("button", { name: "Mobile Close" }));
+    expect(screen.getByRole("button", { name: "Orchard Close" })).toHaveFocus();
+    await user.click(screen.getByRole("button", { name: "Shielded Close" }));
+    expect(screen.getByRole("button", { name: "Orchard Close" })).toHaveFocus();
+  });
+
+  it("preserves pointer selection across Close and backdrop dismissal without refetching ratings", async () => {
+    const user = userEvent.setup();
+    renderMobile();
+    const opener = screen.getByRole("button", { name: /Show Navigation/ });
+    await user.click(opener);
+    let dialog = await screen.findByRole("dialog", { name: "Filters" });
+    await user.click(within(dialog).getByRole("checkbox", { name: "Mobile" }));
+    expect(within(dialog).getByRole("checkbox", { name: "Mobile" })).toBeChecked();
+    await user.click(within(dialog).getByRole("button", { name: "Close" }));
+    await waitFor(() => expect(opener).toHaveFocus());
+    expect(screen.getByText("1 wallet")).toBeInTheDocument();
+    await user.click(opener);
+    dialog = await screen.findByRole("dialog", { name: "Filters" });
+    expect(within(dialog).getByRole("checkbox", { name: "Mobile" })).toBeChecked();
+    await user.click(dialog);
+    await waitFor(() => expect(screen.queryByRole("dialog")).not.toBeInTheDocument());
+    await waitFor(() => expect(opener).toHaveFocus());
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the desktop checkbox filtering and result reset working", async () => {
+    const user = userEvent.setup();
+    render(<WalletList allWallets={wallets} />);
+    const mobile = await screen.findByRole("checkbox", { name: "Mobile" });
+    await user.click(mobile);
+    expect(screen.getByText("1 wallet")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Pocket wallet" })).toBeInTheDocument();
+    await user.click(mobile);
+    expect(screen.getByText("2 wallets")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Opening the wallet filters on a narrow viewport leaves keyboard focus behind the panel, and active filter chips can only be removed by clicking. This gives the panel dialog semantics, initial focus, Tab containment, Escape/backdrop dismissal and focus restoration using the existing Headless UI dependency. Native chip buttons support Enter/Space and move focus to a surviving chip or the opener after removal; the hidden native checkbox controls get a visible focus indicator.

The portaled panel retains the wallet style variables. Filtering selections persist across dismissal and reopening.

Validation: eight focused component tests pass with the actual WalletList, FilterToggle and Headless UI components; the same tests against unchanged main fail seven and pass the existing desktop-filter case. The tests stub the language context, wallet cards and initial ratings request. Responsive sidebar visibility is simulated in JSDOM; full app build/typecheck, browser layout, visual contrast and native screen-reader behavior were not tested.

Implemented with AI assistance and independently reviewed by a separate AI reviewer.

Zcash unified receiving address, as permitted by CONTRIBUTING.md:

u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq
