### PR TITLE
fix(projects): supply responsive image sizing and local sources

### DIFF
--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -24,7 +24,7 @@ const projects = [
     description: "Zaino is an Indexer, developed in Rust by the Zingo team, that aims to replace lightwalletd and to push forward the zcashd deprecation project",
     link: "https://zechub.wiki/zcash-tech/zaino#content",
     imageUrl:
-      "https://zechub.wiki/_next/image?url=%2Fcontent-banners%2Fbannertech.png&w=1920&q=75",
+      "/content-banners/bannertech.png",
   },
   {
     title: "FROST for Zcash",

--- a/src/components/PrivacySet/ProjectCards/ProjectCards.module.css
+++ b/src/components/PrivacySet/ProjectCards/ProjectCards.module.css
@@ -18,11 +18,15 @@
   align-items: center;
 }
 
-.header .image {
+.header .imageFrame {
+  position: relative;
   width: 100%; 
   height: 240px; 
-  object-fit: cover;
   margin-bottom: 24px;
+}
+
+.header .image {
+  object-fit: cover;
 }
 
 /* .header  */
@@ -78,24 +82,27 @@
 
 /* On mobile devices (max-width: 480px) */
 @media (max-width: 480px) {
-  .header .image {
+  .header .imageFrame {
     height: 160px;  /* Reduce the height for smaller screens */
+  }
+  .header .image {
     object-fit: contain;
   }
 }
 
 /* On small tablets (481px to 768px) */
 @media (max-width: 768px) {
-  .header .image {
+  .header .imageFrame {
     height: 200px;  /* Slightly reduce the height for tablets */
-    /* object-fit: contain; */
   }
 }
 
 /* On medium to larger screens (769px and up) */
 @media (min-width: 769px) {
-  .header .image {
+  .header .imageFrame {
     height: 240px; /* Default height for larger screens */
+  }
+  .header .image {
     object-fit: cover;
   }
 }

--- a/src/components/PrivacySet/ProjectCards/ProjectCards.tsx
+++ b/src/components/PrivacySet/ProjectCards/ProjectCards.tsx
@@ -21,7 +21,15 @@ const ProjectCards: React.FC<CardsProps> = ({
   return (
     <div className={`${styles.card } dark:bg-slate-800`}>
       <div className={styles.header}>
-        <Image src={imageSrc} alt={title} className={styles.image} />
+        <div className={styles.imageFrame}>
+          <Image
+            src={imageSrc}
+            alt={title}
+            fill
+            sizes="(min-width: 1024px) 33vw, (min-width: 600px) 50vw, 100vw"
+            className={styles.image}
+          />
+        </div>
         <h2 className={`dark:text-slate-300 ${styles.title}`}>{title}</h2>
       </div>
       <div className={styles.body}>
@@ -41,4 +49,3 @@ const ProjectCards: React.FC<CardsProps> = ({
 };
 
 export default ProjectCards;
- 

--- a/src/lib/__tests__/projectCardsImages.test.tsx
+++ b/src/lib/__tests__/projectCardsImages.test.tsx
@@ -1,0 +1,53 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ProjectCards from "@/components/PrivacySet/ProjectCards/ProjectCards";
+import Grid from "@/components/Grid/Grid";
+
+// Keep the real Next Image implementation; only routing is outside this test.
+jest.mock("@/i18n/navigation", () => ({
+  Link: (props: React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props} />,
+}));
+
+describe("Project card images", () => {
+  it("renders a string image source while preserving the card content and link", () => {
+    render(
+      <ProjectCards
+        title="Example project"
+        description="Project description"
+        imageSrc="/content-banners/bannertech.png"
+        link="https://example.com/project"
+      >
+        <span>Additional project detail</span>
+      </ProjectCards>,
+    );
+
+    const image = screen.getByRole("img", { name: "Example project" });
+    const optimized = new URL(image.getAttribute("src")!, "https://example.com");
+    expect(optimized.searchParams.get("url")).toBe("/content-banners/bannertech.png");
+    expect(image).toHaveAttribute("sizes");
+    expect(image.getAttribute("srcset")).toMatch(/\d+w/);
+    expect(screen.getByRole("heading", { name: "Example project" })).toBeInTheDocument();
+    expect(screen.getByText("Project description")).toBeInTheDocument();
+    expect(screen.getByText("Additional project detail")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Read more" })).toHaveAttribute(
+      "href", "https://example.com/project",
+    );
+  });
+
+  it("renders the current project grid with locally sourced optimized images", () => {
+    render(<Grid />);
+
+    const images = screen.getAllByRole("img");
+    expect(images).toHaveLength(11);
+    expect(screen.getAllByRole("heading", { level: 2 })).toHaveLength(images.length);
+    expect(screen.getAllByRole("link", { name: "Read more" })).toHaveLength(images.length);
+    for (const image of images) {
+      const optimized = new URL(image.getAttribute("src")!, "https://example.com");
+      expect(optimized.searchParams.get("url")).toMatch(/^\/content-(images|banners)\//);
+      expect(image).toHaveAttribute("sizes");
+    }
+    const zaino = screen.getByRole("img", { name: "Zaino Indexer" });
+    const optimized = new URL(zaino.getAttribute("src")!, "https://example.com");
+    expect(optimized.searchParams.get("url")).toBe("/content-banners/bannertech.png");
+  });
+});


### PR DESCRIPTION
Project cards pass string sources to Next Image without dimensions or `fill`, which raises the required-width error during development/test rendering. Put each image in a positioned frame with `fill` and responsive `sizes`, preserving the existing effective image heights, object fitting, content and links. Use the existing local banner for Zaino instead of passing an absolute optimizer URL back through the optimizer; the current remote image configuration does not include that host.

Validation: two focused Jest/jsdom tests use the real Next Image component and actual project grid (only the locale-aware Link boundary is mocked). Both fail on unchanged main with the required-width error; after the sizing change alone, the grid test still detects Zaino's non-local source; both pass with the complete patch. The tests cover card content and links plus all 11 current project images. Tested with Next 16.2.12 and React 19.2.8. No full application build or browser layout test was run, and this does not claim a verified production outage.

This builds on the existing card/grid work in #115, #200 and #177 and the local image migration in #656. AI-assisted implementation and independent AI review; no claim of independent human review.

Zcash unified address for contribution tips:
u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq
