### PR TITLE
fix: reject invalid Zats input instead of changing its amount

### DIFF
--- a/src/components/Converter/ZecToZatsConverter.tsx
+++ b/src/components/Converter/ZecToZatsConverter.tsx
@@ -26,7 +26,10 @@ export default function ZecToZatsConverter() {
         setBottomValue(Math.round(num * ZEC_TO_ZATS).toString());
       }
     } else {
-      val = val.replace(/[^0-9]/g, '');
+      // Remove display grouping only; reject input that would change amount
+      // if a decimal point, sign, or other character were silently stripped.
+      val = val.replace(/,/g, '');
+      if (!/^\d*$/.test(val)) return;
       setTopValue(val);
       const num = parseFloat(val) || 0;
       setBottomValue((num / ZEC_TO_ZATS).toFixed(8));
@@ -42,7 +45,8 @@ export default function ZecToZatsConverter() {
         setTopValue(Math.round(num * ZEC_TO_ZATS).toString());
       }
     } else {
-      val = val.replace(/[^0-9]/g, '');
+      val = val.replace(/,/g, '');
+      if (!/^\d*$/.test(val)) return;
       setBottomValue(val);
       const num = parseFloat(val) || 0;
       setTopValue((num / ZEC_TO_ZATS).toFixed(8));

--- a/src/components/__tests__/zecToZatsConverter.test.tsx
+++ b/src/components/__tests__/zecToZatsConverter.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import ZecToZatsConverter from '../Converter/ZecToZatsConverter';
+
+describe('ZEC/Zats converter input', () => {
+  it.each([false, true])('rejects invalid Zats input (swapped: %s)', (swapped) => {
+    render(<ZecToZatsConverter />);
+    if (swapped) fireEvent.click(screen.getByRole('button', { name: 'Swap units' }));
+    const inputs = screen.getAllByRole('textbox');
+    const zats = inputs[swapped ? 0 : 1];
+    const zec = inputs[swapped ? 1 : 0];
+
+    // A paste must not silently become a different amount by losing its
+    // decimal point, sign, exponent, or other non-numeric characters.
+    for (const value of ['1.5', '-5', '1e3', '12abc34']) {
+      fireEvent.change(zats, { target: { value } });
+      expect(zats).toHaveValue('100,000,000');
+      expect(zec).toHaveValue('1');
+    }
+  });
+
+  it.each([false, true])('accepts grouped integers and whole Zats (swapped: %s)', (swapped) => {
+    render(<ZecToZatsConverter />);
+    if (swapped) fireEvent.click(screen.getByRole('button', { name: 'Swap units' }));
+    const inputs = screen.getAllByRole('textbox');
+    const zats = inputs[swapped ? 0 : 1];
+    const zec = inputs[swapped ? 1 : 0];
+
+    fireEvent.change(zats, { target: { value: '125,000,000' } });
+    expect(zats).toHaveValue('125,000,000');
+    expect(zec).toHaveValue('1.25000000');
+
+    fireEvent.change(zats, { target: { value: '1' } });
+    expect(zats).toHaveValue('1');
+    expect(zec).toHaveValue('0.00000001');
+
+    fireEvent.change(zec, { target: { value: '0.00000002' } });
+    expect(zats).toHaveValue('2');
+    expect(zec).toHaveValue('0.00000002');
+  });
+});


### PR DESCRIPTION
Pasting `1.5` into the Zats field on `/tools?tool=converter` changes it to `15` and displays `0.00000015 ZEC`. The same sanitizer turns `-5` into `5` and `1e3` into `13`. It removes every non-digit character before conversion.

Only remove the commas used by the field's own display formatting, then reject non-integer input without changing the last valid amount. Apply the same validation to both input handlers so swapping units preserves the behavior.

Validation: four component interaction tests pass. On unchanged main `6c143c5`, the two invalid-input cases fail with actual value `15`; the two valid-conversion cases pass. Tests cover both unit positions, grouped integers, and conversions at one and two Zats. The repository CI library test command also passes (10 suites, 118 tests). `git diff --check` passes. No full-site build or native screen-reader validation was performed for this input-only change.

Would this small fix be eligible for a ZecHub bounty of approximately US$20 equivalent in ZEC? I can follow the bounty approval process before requesting payment.
