### PR TITLE
fix: preserve Unicode in DAO member messages

### DIFF
--- a/src/components/DaoComponents/member-card.tsx
+++ b/src/components/DaoComponents/member-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { encodeMemo, MAX_MEMO_BYTES, memoByteLength } from "@/lib/encodeMemo";
 import MemberModal from "./member-modal";
 import { Link } from "@/i18n/navigation";
 import Image from "next/image";   // ← NEW
@@ -16,21 +17,20 @@ interface MemberCardProps {
   };
 }
 
-function base64UrlEncode(str: string) {
-  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
 export default function MemberCard({ member }: MemberCardProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isFlipped, setIsFlipped] = useState(false);
   const [message, setMessage] = useState("");
+  const messageBytes = memoByteLength(message);
+  const isMessageTooLong = messageBytes > MAX_MEMO_BYTES;
 
   const handleFlip = () => {
     setIsFlipped(!isFlipped);
   };
 
   const handleSend = () => {
-    const encodedMemo = base64UrlEncode(message);
+    const encodedMemo = encodeMemo(message);
+    if (encodedMemo === null) return;
     const uri = `zcash:${member.zcashAddress}?amount=0.01&memo=${encodedMemo}`;
     window.location.href = uri;
     handleFlip();
@@ -124,14 +124,20 @@ export default function MemberCard({ member }: MemberCardProps) {
                     className="w-full p-3 border border-amber-500/20 rounded-lg dark:text-white dark:bg-slate-800/40 focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 transition-all"
                     rows={6}
                     placeholder="Type your message..."
-                    maxLength={512}
+                    maxLength={MAX_MEMO_BYTES}
+                    aria-invalid={isMessageTooLong || undefined}
                     value={message}
                     onChange={(e) => setMessage(e.target.value)}
                   />
                   <div className="absolute bottom-2 right-2 text-slate-400 text-sm bg-slate-800/80 px-2 py-1 rounded">
-                    {message.length}/512
+                    {messageBytes}/{MAX_MEMO_BYTES} bytes
                   </div>
                 </div>
+                {isMessageTooLong && (
+                  <p role="alert" className="mt-2 text-sm text-red-600 dark:text-red-400">
+                    Shorten your message to fit the 512-byte limit.
+                  </p>
+                )}
               </div>
 
               <div className="flex justify-end space-x-3 mt-4">
@@ -146,6 +152,7 @@ export default function MemberCard({ member }: MemberCardProps) {
                 </button>
                 <button
                   onClick={handleSend}
+                  disabled={isMessageTooLong}
                   className="cursor-pointer px-4 py-2 text-sm font-medium text-center text-white bg-green-600 rounded-lg hover:bg-green-700 hover:scale-105 focus:ring-4 focus:outline-none focus:ring-green-300 dark:bg-green-500 dark:hover:bg-green-600 dark:focus:ring-green-800 transition-all"
                 >
                   Send

--- a/src/components/DaoComponents/member-modal.tsx
+++ b/src/components/DaoComponents/member-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { encodeMemo, MAX_MEMO_BYTES, memoByteLength } from "@/lib/encodeMemo";
 
 interface MemberModalProps {
   member: {
@@ -15,10 +16,6 @@ interface MemberModalProps {
   onClose: () => void;
 }
 
-function base64UrlEncode(str: string) {
-  return btoa(str).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
 export default function MemberModal({
   member,
   isOpen,
@@ -26,13 +23,16 @@ export default function MemberModal({
 }: MemberModalProps) {
   const [isFlipped, setIsFlipped] = useState(false);
   const [message, setMessage] = useState("");
+  const messageBytes = memoByteLength(message);
+  const isMessageTooLong = messageBytes > MAX_MEMO_BYTES;
 
   const handleFlip = () => {
     setIsFlipped(!isFlipped);
   };
 
   const handleSend = () => {
-    const encodedMemo = base64UrlEncode(message);
+    const encodedMemo = encodeMemo(message);
+    if (encodedMemo === null) return;
     const uri = `zcash:${member.zcashAddress}?amount=0.01&memo=${encodedMemo}`;
     window.location.href = uri;
     handleFlip();
@@ -169,14 +169,20 @@ export default function MemberModal({
                       className="w-full p-3 border border-amber-500/20 rounded-lg text-white dark:bg-slate-800/40 focus:ring-2 focus:ring-amber-500/50 focus:border-amber-500/50 transition-all resize-none"
                       rows={6}
                       placeholder="Type your message..."
-                      maxLength={512}
+                      maxLength={MAX_MEMO_BYTES}
+                      aria-invalid={isMessageTooLong || undefined}
                       value={message}
                       onChange={(e) => setMessage(e.target.value)}
                     />
                     <div className="absolute bottom-2 right-2 text-slate-400 text-sm bg-slate-800/80 px-2 py-1 rounded">
-                      {message.length}/512
+                      {messageBytes}/{MAX_MEMO_BYTES} bytes
                     </div>
                   </div>
+                  {isMessageTooLong && (
+                    <p role="alert" className="mb-4 text-sm text-red-600 dark:text-red-400">
+                      Shorten your message to fit the 512-byte limit.
+                    </p>
+                  )}
 
                   <div className="flex justify-end space-x-3">
                     <button
@@ -190,6 +196,7 @@ export default function MemberModal({
                     </button>
                     <button
                       onClick={handleSend}
+                      disabled={isMessageTooLong}
                       className="cursor-pointer px-4 py-2 text-sm font-medium text-center text-white bg-green-600 rounded-lg hover:bg-green-700 hover:scale-105 focus:ring-4 focus:outline-none focus:ring-green-300 transition-all"
                     >
                       Send

--- a/src/lib/__tests__/memberMemo.test.tsx
+++ b/src/lib/__tests__/memberMemo.test.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { TextEncoder } from "util";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import MemberCard from "@/components/DaoComponents/member-card";
+import MemberModal from "@/components/DaoComponents/member-modal";
+
+jest.mock("@/i18n/navigation", () => ({
+  Link: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+const member = {
+  name: "Example contributor",
+  description: "Community contributor",
+  imgUrl: "/placeholder.svg",
+  social: [],
+  role: "Member",
+  zcashAddress: "test-recipient",
+};
+
+const originalLocation = Object.getOwnPropertyDescriptor(window, "location")!;
+const originalTextEncoder = Object.getOwnPropertyDescriptor(globalThis, "TextEncoder");
+let requestedUris: string[] = [];
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "TextEncoder", { configurable: true, value: TextEncoder });
+});
+
+beforeEach(() => {
+  requestedUris = [];
+  // Capture the requested URI without navigating or opening a wallet.
+  Object.defineProperty(window, "location", {
+    configurable: true,
+    value: {
+      get href() { return "http://localhost/"; },
+      set href(uri: string) { requestedUris.push(uri); },
+      origin: "http://localhost",
+    },
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  Object.defineProperty(window, "location", originalLocation);
+});
+
+afterAll(() => {
+  if (originalTextEncoder) {
+    Object.defineProperty(globalThis, "TextEncoder", originalTextEncoder);
+  } else {
+    delete (globalThis as { TextEncoder?: unknown }).TextEncoder;
+  }
+});
+
+describe.each(["card", "modal"])("DAO member %s message", (variant) => {
+  function compose(message: string) {
+    render(variant === "card" ? <MemberCard member={member} /> : (
+      <MemberModal member={{ ...member, social: "" }} isOpen onClose={jest.fn()} />
+    ));
+    fireEvent.click(screen.getByRole("button", { name: "Message" }));
+    fireEvent.change(screen.getByPlaceholderText("Type your message..."), {
+      target: { value: message },
+    });
+  }
+
+  it.each(["Hello!", "Café", "こんにちは 👋"])("preserves the UTF-8 message %s", (message) => {
+    compose(message);
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    const encoded = Buffer.from(message, "utf8").toString("base64url");
+    expect(requestedUris).toEqual([`zcash:test-recipient?amount=0.01&memo=${encoded}`]);
+  });
+
+  it("accepts exactly 512 UTF-8 bytes", () => {
+    const message = "é".repeat(256);
+    compose(message);
+    expect(screen.getByText("512/512 bytes")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Send" }));
+    expect(requestedUris).toHaveLength(1);
+    const encoded = requestedUris[0].split("memo=")[1];
+    expect(Buffer.from(encoded, "base64url").equals(Buffer.from(message, "utf8"))).toBe(true);
+  });
+
+  it("keeps an over-limit draft and allows sending after shortening it", () => {
+    const message = "🙂".repeat(129);
+    compose(message);
+    expect(screen.getByText("516/512 bytes")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Shorten your message");
+    const send = screen.getByRole("button", { name: "Send" });
+    expect(send).toBeDisabled();
+    fireEvent.click(send);
+    expect(requestedUris).toEqual([]);
+    const input = screen.getByPlaceholderText("Type your message...");
+    expect(input).toHaveValue(message);
+    fireEvent.change(input, { target: { value: "🙂".repeat(128) } });
+    expect(send).toBeEnabled();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    fireEvent.click(send);
+    expect(requestedUris).toHaveLength(1);
+    expect(Buffer.from(requestedUris[0].split("memo=")[1], "base64url").length).toBe(512);
+  });
+});

--- a/src/lib/encodeMemo.ts
+++ b/src/lib/encodeMemo.ts
@@ -1,0 +1,16 @@
+export const MAX_MEMO_BYTES = 512;
+
+export function memoByteLength(message: string): number {
+  return new TextEncoder().encode(message).length;
+}
+
+/** Encode UTF-8 text for a ZIP 321 memo, or reject an over-limit draft. */
+export function encodeMemo(message: string): string | null {
+  const bytes = new TextEncoder().encode(message);
+  if (bytes.length > MAX_MEMO_BYTES) return null;
+
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}


### PR DESCRIPTION
The DAO card and expanded member modal pass JavaScript text directly to `btoa`: `Café` produces non-UTF-8 bytes, and Japanese text or emoji can throw before a wallet link is requested. This uses one shared UTF-8/base64url encoder for both forms and counts the encoded bytes. Drafts over the ZIP 321 limit retain their text, show a shortening message, and cannot be sent until they fit.

Validation: 10 focused component tests pass, covering ASCII, accented text, Japanese/emoji, the exact 512-byte boundary, and editing an over-limit draft back into range. The same tests on unchanged main pass 2 and fail 8. They use a local navigation capture with a synthetic recipient; no wallet was opened or payment sent. Next Image is real; the locale Link is mocked. No full app build, typecheck, or native wallet test was run.

This builds on the DAO interface introduced in #262 and retains its existing amount and recipient handling. Prepared with AI assistance and independently reviewed by a second AI agent.

Reference: [ZIP 321 memo format and byte limit](https://zips.z.cash/zip-0321#query-keys).

Unified receiving address: `u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
