### PR TITLE
fix(grants): parse grouped ZEC disbursement amounts

### DIFF
--- a/src/lib/__tests__/grantNumbers.test.ts
+++ b/src/lib/__tests__/grantNumbers.test.ts
@@ -1,0 +1,50 @@
+import { parseNumber } from "../zips/grantParsers";
+import { transformGrantData } from "../zips/transformGrantData";
+import { computeFinancialStats, computeStats } from "../zips/helpers";
+import type { RawGrantRow } from "@/types/grants";
+
+describe("formatted ZEC disbursements", () => {
+  it.each<[string, number]>([
+    ["5,417.12", 5417.12],
+    ["1,698.27", 1698.27],
+    [" 1,234,567.12345678 ", 1234567.12345678],
+    ["-1,234.5", -1234.5],
+    ["1234.5", 1234.5],
+    ["0.00000001", 0.00000001],
+    ["0", 0],
+  ])("parses %s as %s", (input, expected) => {
+    expect(parseNumber(input)).toBe(expected);
+  });
+
+  it.each([undefined, "", " ", "N/A", "NaN", "Infinity", "1e999", "1,23.45", "1,,234"])(
+    "treats missing or invalid input %s as unavailable",
+    (input) => {
+      expect(parseNumber(input)).toBeNull();
+    },
+  );
+
+  it("retains grants with grouped amounts in both dashboard total paths", () => {
+    // Amounts and project names from the public ZCG sheet (2026-09-08):
+    // https://docs.google.com/spreadsheets/d/1FQ28rDCyRW0TiNxrm3rgD8ai2KGUsXAjPieQmI1kKKg/edit#gid=803214474
+    const row = (project: string, milestone: string, zec: string): RawGrantRow => ({
+      Project: project,
+      Grantee: project,
+      "Category (as determined by ZCG)": "Wallets",
+      Milestone: milestone,
+      "ZEC Disbursed": zec,
+    });
+    const grants = transformGrantData([
+      row("YWallet", "1", "5,417.12"),
+      row("Keystone Hardware Wallet", "2", "1,698.27"),
+      row("Keystone Hardware Wallet", "3", "1,698.27"),
+      row("Unpaid example", "1", "N/A"),
+    ]);
+
+    expect(grants[0].summary.totalZecDisbursed).toBeCloseTo(5417.12, 8);
+    expect(grants[1].summary.totalZecDisbursed).toBeCloseTo(3396.54, 8);
+    expect(grants[2].milestones[0].zecDisbursed).toBeNull();
+    expect(grants[2].summary.completedMilestones).toBe(0);
+    expect(computeStats(grants).totalZec).toBeCloseTo(8813.66, 8);
+    expect(computeFinancialStats(grants).totalZecDisbursed).toBeCloseTo(8813.66, 8);
+  });
+});

--- a/src/lib/zips/grantParsers.ts
+++ b/src/lib/zips/grantParsers.ts
@@ -9,7 +9,15 @@ export const parseMoney = (value?: string): number | null => {
 export const parseNumber = (value?: string): number | null => {
   if (!value || value.trim() === "") return null;
 
-  return Number(value);
+  const text = value.trim();
+  // Sheets supplies formatted values, including thousands separators. Only
+  // strip commas from valid groups so malformed amounts are not reinterpreted.
+  if (text.includes(",") && !/^[+-]?\d{1,3}(?:,\d{3})+(?:\.\d+)?$/.test(text)) {
+    return null;
+  }
+
+  const number = Number(text.replace(/,/g, ""));
+  return Number.isFinite(number) ? number : null;
 };
 
 export const normalizeStatus = (status: string): GrantStatus => {


### PR DESCRIPTION
The public ZCG sheet contains formatted ZEC disbursements such as `5,417.12` and `1,698.27`. `getZCGrantsData` passes formatted cell values to `parseNumber`, where `Number()` produces `NaN`. This poisons each affected grant's total: `computeStats` skips the grant, while `computeFinancialStats` propagates `NaN`.

Parse valid comma-separated thousands groups and return `null` for invalid or non-finite input. Ordinary numeric values and zero retain their behavior. Tests cover the three grouped values observed in the [public sheet](https://docs.google.com/spreadsheets/d/1FQ28rDCyRW0TiNxrm3rgD8ai2KGUsXAjPieQmI1kKKg/edit#gid=803214474) on September 8, totaling 8,813.66 ZEC, plus both dashboard aggregation paths. This reproduces the data-processing defect locally; it does not claim a separately verified production display total.

Validation: the 17 new regression cases produce 11 failures and 6 passes with the original parser. With the fix, `node node_modules/jest/bin/jest.js src/lib --ci --runInBand` passes all 135 tests across 11 suites. `git diff --check` passes. Dependencies were installed from the existing lockfile with lifecycle scripts disabled. No full application build or browser rendering test was run.

Implementation, tests and self-review used OpenAI Codex; no independent human review is claimed. Please consider this under the [published development contribution program](https://github.com/ZecHub/zechub/blob/main/site/contribute/Contributing_Guide.md) and confirm eligibility and any reward amount. No award is assumed; payout details can be arranged privately after approval.
