### PR TITLE
fix: filter Arborist calls by their archived year

### DIFF
--- a/src/app/[locale]/aborist-calls/ArboristCallsPage.tsx
+++ b/src/app/[locale]/aborist-calls/ArboristCallsPage.tsx
@@ -37,6 +37,10 @@ export const metadata: Metadata = genMetadata({
   url: "https://zechub.wiki/aborist-calls",
 });
 
+const availableYears = [
+  ...new Set(arboristCalls.map((call) => call.date.slice(-4))),
+].sort((a, b) => Number(b) - Number(a));
+
 export default function ArboristCallsPage() {
   const [searchTerm, setSearchTerm] = useState("");
   const [statusFilter, setStatusFilter] = useState("all");
@@ -50,7 +54,7 @@ export default function ArboristCallsPage() {
     const matchesStatus =
       statusFilter === "all" || call.status.toLowerCase() === statusFilter;
 
-    const callYear = call.date.includes("2025") ? "2025" : "2024";
+    const callYear = call.date.slice(-4);
     const matchesYear = yearFilter === "all" || callYear === yearFilter;
 
     return matchesSearch && matchesStatus && matchesYear;
@@ -150,9 +154,11 @@ export default function ArboristCallsPage() {
               </SelectTrigger>
               <SelectContent className="bg-yellow-300 dark:bg-yellow-500">
                 <SelectItem value="all">All Years</SelectItem>
-                <SelectItem value="2025">2025</SelectItem>
-                <SelectItem value="2024">2024</SelectItem>
-                <SelectItem value="2023">2023</SelectItem>
+                {availableYears.map((year) => (
+                  <SelectItem key={year} value={year}>
+                    {year}
+                  </SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>

--- a/src/lib/__tests__/arboristCallsFilters.test.tsx
+++ b/src/lib/__tests__/arboristCallsFilters.test.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { arboristCalls } from "@/constants/arboristCalls";
+import ArboristCallsPage from "@/app/[locale]/aborist-calls/ArboristCallsPage";
+
+jest.mock("@/lib/helpers", () => ({ genMetadata: () => ({}) }));
+
+const originalScrollIntoView = Element.prototype.scrollIntoView;
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = jest.fn();
+});
+
+afterAll(() => {
+  Element.prototype.scrollIntoView = originalScrollIntoView;
+});
+
+async function chooseFilter(index: number, option: string) {
+  fireEvent.keyDown(screen.getAllByRole("combobox")[index], {
+    key: "ArrowDown",
+  });
+  fireEvent.click(await screen.findByRole("option", { name: option, exact: true }));
+}
+
+function visibleCallLabels() {
+  return screen
+    .getAllByRole("row")
+    .slice(1)
+    .map((row) => {
+      return within(row).getAllByRole("cell")[0].textContent?.replace("🎉", "").trim();
+    });
+}
+
+describe("Arborist call archive filters", () => {
+  it("offers every archived year in newest-first order", async () => {
+    render(<ArboristCallsPage />);
+    fireEvent.keyDown(screen.getAllByRole("combobox")[1], { key: "ArrowDown" });
+
+    const options = await screen.findAllByRole("option");
+    const years = [
+      ...new Set(arboristCalls.map((call) => new Date(call.date).getFullYear())),
+    ]
+      .sort((a, b) => b - a)
+      .map(String);
+    expect(options.map((option) => option.textContent)).toEqual([
+      "All Years",
+      ...years,
+    ]);
+  });
+
+  it.each([2020, 2021, 2022, 2023, 2024, 2025])(
+    "shows exactly the archived calls from %i",
+    async (year) => {
+      render(<ArboristCallsPage />);
+      await chooseFilter(1, String(year));
+
+      const expected = arboristCalls.filter(
+        (call) => new Date(call.date).getFullYear() === year
+      );
+      expect(expected.length).toBeGreaterThan(0);
+      expect(visibleCallLabels()).toEqual(expected.map((call) => `#${call.id}`));
+      expect(
+        screen.getByText(`Showing ${expected.length} of ${arboristCalls.length} calls`)
+      ).toBeVisible();
+    }
+  );
+
+  it("combines year, search and status filters and restores the full archive", async () => {
+    render(<ArboristCallsPage />);
+    await chooseFilter(1, "2023");
+    const example = arboristCalls.find(
+      (call) => new Date(call.date).getFullYear() === 2023
+    )!;
+    fireEvent.change(screen.getByPlaceholderText("Call # or date..."), {
+      target: { value: example.date },
+    });
+    await chooseFilter(0, "Completed");
+    expect(visibleCallLabels()).toEqual([`#${example.id}`]);
+
+    await chooseFilter(0, "Upcoming");
+    expect(screen.getByText(`Showing 0 of ${arboristCalls.length} calls`)).toBeVisible();
+    expect(screen.getAllByRole("row")).toHaveLength(1);
+
+    await chooseFilter(0, "All Status");
+    await chooseFilter(1, "All Years");
+    fireEvent.change(screen.getByPlaceholderText("Call # or date..."), {
+      target: { value: "" },
+    });
+    expect(visibleCallLabels()).toEqual(arboristCalls.map((call) => `#${call.id}`));
+  });
+});


### PR DESCRIPTION
The Arborist archive currently treats every non-2025 call as 2024: selecting 2023 hides all 26 matching calls, selecting 2024 returns 94 instead of 26, and 2020–2022 are unavailable in the year menu. This reads the year from each committed date and builds the menu from the archive’s years, newest first.

Validation: eight regression tests exercise the actual page and Radix dropdowns against the committed archive, including every archived year and combined search/status/year filtering. The unchanged component passes one and fails seven; the fix passes all eight. All 126 tests in the existing `src/lib` CI scope pass locally (`npx jest src/lib --ci --runInBand`), including the eight new regressions. No full application build or browser run was performed.

Prepared with AI assistance and independently reviewed by a second AI agent. Submitted for normal maintainer review.

Unified receiving address: `u1s8ge2hna8ez629msqu7z6rsugsrfartq93aeas77305e2r6w5gvcx9re0w2ue9e9cn636farrq0edgyzzqupd3cenntmw5rfpm6hjw56wwt9r54aqkmjqxz359y4rdsc6dquqfa5rxsjzvm7kkdvmekyaxaj3ks98wk0l9dh2yf7j6uq`
