### PR TITLE
fix(ci): run Playwright tests and repair dashboard selectors

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,17 +1,47 @@
 name: Playwright Tests
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   test:
-    timeout-minutes: 60
+    timeout-minutes: 25
     runs-on: ubuntu-latest
+    env:
+      # Match the existing egress job: no production credentials are required.
+      NEXT_PUBLIC_SUPABASE_URL: "https://dummy.supabase.co"
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: "dummy"
+      SUPABASE_SERVICE_ROLE_KEY: "dummy"
+      OPENAI_API_KEY: ""
+      NEXT_TELEMETRY_DISABLED: "1"
     steps:
-    - uses: actions/checkout@v7
-    - uses: actions/setup-node@v7
-      with:
-        node-version: lts/*
-    - name: Install dependencies
-      run: yarn install --frozen-lockfile
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile --ignore-scripts
+      - name: Install Playwright Chromium
+        run: yarn playwright install --with-deps chromium
+      - name: Build
+        run: yarn build
+      # playwright.config.ts starts the built app and enforces readiness.
+      - name: Run all Playwright tests
+        run: yarn playwright test
+      - name: Upload Playwright report and traces
+        uses: actions/upload-artifact@v7
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/e2e/export-dashboard.spec.ts
+++ b/e2e/export-dashboard.spec.ts
@@ -1,50 +1,50 @@
 import { expect, test } from "@playwright/test";
 
-const devURL = "http://localhost:3000/";
+// Keep these UI checks independent of changing pool totals and GitHub API limits.
+const amounts = { sprout: 101, sapling: 202, orchard: 303, ironwood: 404 };
 
 test.describe("Dashboard", () => {
-  test("has export button", async ({ page }) => {
-    await page.goto(devURL);
+  test.beforeEach(async ({ page }) => {
+    for (const [pool, supply] of Object.entries(amounts)) {
+      await page.route(`**/data/zcash/${pool}_supply.json`, (route) =>
+        route.fulfill({
+          json: [
+            { close: "09/01/2026", supply: supply - 1 },
+            { close: "09/02/2026", supply },
+          ],
+        }),
+      );
+    }
+    await page.route("**/api/data-updated?*", (route) =>
+      route.fulfill({
+        json: [{ commit: { committer: { date: "2026-09-02T00:00:00Z" } } }],
+      }),
+    );
+    // These tests cover the dashboard, not the changing global navigation menu.
+    await page.goto("/dashboard");
+  });
 
-    await page.getByRole("link", { name: /dashboard/i }).click();
+  test("has export button", async ({ page }) => {
     await expect(
-      page.getByRole("button", { name: "Export (PNG)" })
+      page.getByRole("button", { name: "Export PNG", exact: true }),
     ).toBeVisible();
   });
 
-  test("has name of Sprout pool plus amount of zec", async ({ page }) => {
-    await page.goto(devURL);
-
-    await page.getByRole("link", { name: /dashboard/i }).click();
-
-    await page.getByRole("button", { name: "Sprout Pool" }).click();
-
-    await page.getByRole("button", { name: "Export (PNG)" }).click();
-
-    await expect(page.getByText(/ZEC in Sprout Pool/i)).toBeVisible();
-  });
-  
-  test("has name of Sapling pool plus amount of zec", async ({ page }) => {
-    await page.goto(devURL);
-
-    await page.getByRole("link", { name: /dashboard/i }).click();
-
-    await page.getByRole("button", { name: "Sapling Pool" }).click();
-
-    await page.getByRole("button", { name: "Export (PNG)" }).click();
-
-    await expect(page.getByText(/ZEC in Sapling Pool/i)).toBeVisible();
-  });
-
-  test("has name of Orchard pool plus amount of zec", async ({ page }) => {
-    await page.goto(devURL);
-
-    await page.getByRole("link", { name: /dashboard/i }).click();
-
-    await page.getByRole("button", { name: "Orchard Pool" }).click();
-
-    await page.getByRole("button", { name: "Export (PNG)" }).click();
-
-    await expect(page.getByText(/ZEC in Orchard Pool/i)).toBeVisible();
-  });
+  for (const pool of ["sprout", "sapling", "orchard"] as const) {
+    const label = pool.charAt(0).toUpperCase() + pool.slice(1);
+    test(`has name of ${label} pool plus amount of zec`, async ({ page }) => {
+      // The current UI uses a native pool select, separate from the year select.
+      const poolSelect = page.getByRole("combobox").filter({
+        has: page.getByRole("option", { name: "All Pools", exact: true }),
+      });
+      await poolSelect.selectOption(pool);
+      const amount = page.getByText(
+        `${label} Shielded: ${amounts[pool]} ZEC`,
+        { exact: true },
+      );
+      await expect(amount).toBeVisible();
+      await page.getByRole("button", { name: "Export PNG", exact: true }).click();
+      await expect(amount).toBeVisible();
+    });
+  }
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,78 +1,34 @@
 import { defineConfig, devices } from "@playwright/test";
 
-/**
- * Read environment variables from file.
- * https://github.com/motdotla/dotenv
- */
-// import dotenv from 'dotenv';
-// dotenv.config({ path: path.resolve(__dirname, '.env') });
+// egress-check.yml already starts and checks its own server.
+const externalBaseURL = process.env.EGRESS_BASE_URL || process.env.TOOLS_BASE_URL;
+const baseURL = externalBaseURL || "http://localhost:3000";
 
-/**
- * See https://playwright.dev/docs/test-configuration.
- */
 export default defineConfig({
   testDir: "./e2e",
-  /* Run tests in files in parallel */
   fullyParallel: true,
-  /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
-  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: "html",
-  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
-
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    baseURL,
     trace: "on-first-retry",
   },
-
-  /* Configure projects for major browsers */
   projects: [
     {
       name: "chromium",
       use: { ...devices["Desktop Chrome"] },
     },
-
-    // {
-    //   name: 'firefox',
-    //   use: { ...devices['Desktop Firefox'] },
-    // },
-
-    // {
-    //   name: 'webkit',
-    //   use: { ...devices['Desktop Safari'] },
-    // },
-
-    /* Test against mobile viewports. */
-    // {
-    //   name: 'Mobile Chrome',
-    //   use: { ...devices['Pixel 5'] },
-    // },
-    // {
-    //   name: 'Mobile Safari',
-    //   use: { ...devices['iPhone 12'] },
-    // },
-
-    /* Test against branded browsers. */
-    // {
-    //   name: 'Microsoft Edge',
-    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    // },
-    // {
-    //   name: 'Google Chrome',
-    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    // },
   ],
-
-  /* Run your local dev server before starting the tests */
-  // webServer: {
-  //   command: 'npm run start',
-  //   url: 'http://127.0.0.1:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  // CI builds first; Playwright owns the process and fails if it is not ready.
+  // Explicit external URLs preserve workflows that manage their own server.
+  webServer: externalBaseURL
+    ? undefined
+    : {
+        command: process.env.CI ? "yarn start" : "yarn dev",
+        url: baseURL,
+        timeout: 120_000,
+        reuseExistingServer: !process.env.CI,
+      },
 });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: "html",
+  reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL,
     trace: "on-first-retry",


### PR DESCRIPTION
The Playwright Tests workflow currently stops after dependency installation, so a green job does not mean tests ran. This change installs Chromium, builds the app, runs the full existing Playwright suite, and uploads the HTML report and failure traces for seven days. Playwright starts the production server in CI and waits for readiness; explicit EGRESS_BASE_URL / TOOLS_BASE_URL values retain externally managed server behavior.

The four existing dashboard tests now use the current native pool selector and Export PNG label, navigate directly to /dashboard, and assert deterministic pool amounts with small supply and last-update fixtures. The six tools URL tests and four egress cases remain unchanged. No product code or other workflow files are changed; no tests are skipped or added.

Validation on GitHub-hosted Ubuntu / Node 24, commit eb943e72a191809d4eab641ac3094f10ad442d51:
- [Build and full Playwright run](https://github.com/pranavharan02/zechub-wiki/actions/runs/34273848183/job/102221878195): 14 passed (29.8s), with all individual results visible in the Run all Playwright tests step.
- [Unit tests](https://github.com/pranavharan02/zechub-wiki/actions/runs/34273848186): passed.
- [Existing egress workflow with the server configuration change](https://github.com/pranavharan02/zechub-wiki/actions/runs/34272568753): passed.

The dashboard assertions cover button visibility, pool selection, displayed amounts and the existing export click; they do not validate the downloaded PNG contents. The dummy CI environment retains existing missing-content/image warnings.

Prepared with an AI coding assistant under the account owner's authorization, using the GitHub browser editor and hosted CI. Submitted for review in response to the ZecHub bounty “The Playwright Tests job passes without running a test”; bounty acceptance and payment are not assumed.