### PR TITLE
fix: support keyboard navigation in the language picker

### DIFF
--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useLayoutEffect } from 'react';
+import { useState, useRef, useEffect, useLayoutEffect, useId, type KeyboardEvent } from 'react';
 import { Globe } from 'lucide-react';
 import { useLanguage, LANGUAGES } from '@/context/LanguageContext';
 import { useRouter, usePathname } from '@/i18n/navigation';
@@ -12,6 +12,10 @@ export function LanguageSwitcher() {
   const router = useRouter();
   const pathname = usePathname();
   const containerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const restoreFocusRef = useRef(false);
+  const listboxId = useId();
   const desktopLabelRef = useRef<HTMLSpanElement>(null);
   const mobileFlagRef = useRef<HTMLSpanElement>(null);
 
@@ -26,11 +30,23 @@ export function LanguageSwitcher() {
     }
   }, [locale]);
 
+  useLayoutEffect(() => {
+    if (isOpen) {
+      const selectedIndex = Math.max(0, LANGUAGES.findIndex((lang) => lang.code === locale));
+      optionRefs.current[selectedIndex]?.focus();
+    } else if (restoreFocusRef.current) {
+      // Locale changes remount the keyed trigger, so restore focus after commit.
+      triggerRef.current?.focus();
+      restoreFocusRef.current = false;
+    }
+  }, [isOpen, locale]);
+
   // ── Outside-click handler ─────────────────────────────────────────────────
   useEffect(() => {
     if (!isOpen) return;
     const handleOutsideClick = (e: MouseEvent) => {
       if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        restoreFocusRef.current = false;
         setIsOpen(false);
       }
     };
@@ -38,7 +54,41 @@ export function LanguageSwitcher() {
     return () => document.removeEventListener('mousedown', handleOutsideClick);
   }, [isOpen]);
 
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (isOpen && event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      restoreFocusRef.current = true;
+      setIsOpen(false);
+      return;
+    }
+
+    if (event.altKey || event.ctrlKey || event.metaKey) return;
+    const isArrowKey = event.key === 'ArrowDown' || event.key === 'ArrowUp';
+    if (!isOpen) {
+      if (isArrowKey) {
+        event.preventDefault();
+        setIsOpen(true);
+      }
+      return;
+    }
+    if (!isArrowKey && event.key !== 'Home' && event.key !== 'End') return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    const currentIndex = optionRefs.current.findIndex((option) => option === document.activeElement);
+    const selectedIndex = Math.max(0, LANGUAGES.findIndex((lang) => lang.code === locale));
+    let nextIndex = currentIndex < 0 ? selectedIndex : currentIndex;
+    if (event.key === 'Home') nextIndex = 0;
+    else if (event.key === 'End') nextIndex = LANGUAGES.length - 1;
+    else if (currentIndex >= 0) {
+      nextIndex = Math.max(0, Math.min(LANGUAGES.length - 1, currentIndex + (event.key === 'ArrowDown' ? 1 : -1)));
+    }
+    optionRefs.current[nextIndex]?.focus();
+  };
+
   const handleSelect = (code: string) => {
+    restoreFocusRef.current = true;
     setLocale(code);
     setIsOpen(false);
     // Every language ships curated content and a next-intl route, so always
@@ -48,15 +98,26 @@ export function LanguageSwitcher() {
   };
 
   return (
-    <div className="relative notranslate" ref={containerRef} translate="no">
+    <div
+      className="relative notranslate"
+      ref={containerRef}
+      translate="no"
+      onKeyDown={handleKeyDown}
+      onBlur={(event) => {
+        if (!event.currentTarget.contains(event.relatedTarget)) setIsOpen(false);
+      }}
+    >
       <button
         type="button"
         key={locale}
+        ref={triggerRef}
+        tabIndex={isOpen ? -1 : 0}
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 hover:bg-slate-200 dark:hover:bg-slate-700 transition-all cursor-pointer"
+        className="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 hover:bg-slate-200 dark:hover:bg-slate-700 focus-visible:ring-2 focus-visible:ring-amber-500 transition-all cursor-pointer"
         aria-label="Select language"
         aria-expanded={isOpen}
         aria-haspopup="listbox"
+        aria-controls={isOpen ? listboxId : undefined}
       >
         <Globe className="w-4 h-4" />
         <span
@@ -76,18 +137,21 @@ export function LanguageSwitcher() {
 
       {isOpen && (
         <div
+          id={listboxId}
           role="listbox"
           aria-label="Language options"
           className="absolute right-0 mt-2 w-52 rounded-lg bg-slate-50 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 shadow-xl z-50 overflow-hidden max-h-80 overflow-y-auto"
         >
-          {LANGUAGES.map((lang) => (
+          {LANGUAGES.map((lang, index) => (
             <button
               key={lang.code}
               type="button"
+              ref={(option) => { optionRefs.current[index] = option; }}
+              tabIndex={-1}
               role="option"
               aria-selected={lang.code === locale}
               onClick={() => handleSelect(lang.code)}
-              className={`w-full text-left px-4 py-2.5 flex items-center gap-3 hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors text-sm cursor-pointer ${
+              className={`w-full text-left px-4 py-2.5 flex items-center gap-3 hover:bg-slate-200 dark:hover:bg-slate-700 focus-visible:bg-slate-200 dark:focus-visible:bg-slate-700 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-amber-500 transition-colors text-sm cursor-pointer ${
                 lang.code === locale ? 'bg-slate-200 dark:bg-slate-700 font-semibold' : ''
               }`}
             >

--- a/src/components/__tests__/languageSwitcher.test.tsx
+++ b/src/components/__tests__/languageSwitcher.test.tsx
@@ -1,0 +1,239 @@
+import { useCallback, useState } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { LANGUAGES, useLanguage } from "@/context/LanguageContext";
+import { LanguageSwitcher } from "../LanguageSwitcher";
+
+const mockSetLocale = jest.fn();
+const mockReplace = jest.fn();
+
+jest.mock("@/context/LanguageContext", () => ({
+  LANGUAGES: [
+    { code: "en", label: "English", nativeLabel: "English", flag: "🇺🇸" },
+    { code: "es", label: "Spanish", nativeLabel: "Español", flag: "🇪🇸" },
+    { code: "fr", label: "French", nativeLabel: "Français", flag: "🇫🇷" },
+    { code: "ja", label: "Japanese", nativeLabel: "日本語", flag: "🇯🇵" },
+  ],
+  useLanguage: jest.fn(),
+}));
+
+jest.mock("@/i18n/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  usePathname: () => "/dashboard",
+}));
+
+jest.mock("@/i18n/routing", () => ({
+  routing: { locales: ["en", "es", "fr", "ja"] },
+}));
+
+// Keep locale changes real so selection exercises the trigger's locale update
+// and any resulting remount, rather than succeeding with a frozen mock value.
+function useMockLanguage() {
+  const [locale, setLocaleState] = useState("es");
+  const setLocale = useCallback((code: string) => {
+    mockSetLocale(code);
+    setLocaleState(code);
+  }, []);
+
+  return {
+    locale,
+    setLocale,
+    currentLanguage: LANGUAGES.find((language) => language.code === locale)!,
+    t: {},
+  };
+}
+
+function renderPicker() {
+  return render(
+    <>
+      <button type="button">Before picker</button>
+      <LanguageSwitcher />
+      <button type="button">After picker</button>
+    </>,
+  );
+}
+
+function trigger() {
+  return screen.getByRole("button", { name: "Select language" });
+}
+
+function option(name: RegExp) {
+  return screen.getByRole("option", { name });
+}
+
+function expectNoSelection() {
+  expect(mockSetLocale).not.toHaveBeenCalled();
+  expect(mockReplace).not.toHaveBeenCalled();
+}
+
+describe("LanguageSwitcher keyboard and pointer behavior", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useLanguage).mockImplementation(useMockLanguage);
+  });
+
+  it("starts closed without taking focus from another control", () => {
+    render(<button type="button">Already focused</button>);
+    const outside = screen.getByRole("button", { name: "Already focused" });
+    outside.focus();
+
+    renderPicker();
+
+    expect(outside).toHaveFocus();
+    expect(trigger()).toHaveAttribute("aria-expanded", "false");
+    expect(trigger()).toHaveTextContent("Español");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expectNoSelection();
+  });
+
+  it("opens on click with focus on the current, non-first language", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+
+    await user.click(trigger());
+
+    expect(trigger()).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("listbox", { name: "Language options" })).toBeVisible();
+    expect(option(/Español/)).toHaveFocus();
+    expect(option(/Español/)).toHaveAttribute("aria-selected", "true");
+    expect(option(/English/)).toHaveAttribute("aria-selected", "false");
+    expectNoSelection();
+  });
+
+  it.each([
+    ["Enter", "{Enter}"],
+    ["Space", " "],
+    ["ArrowDown", "{ArrowDown}"],
+    ["ArrowUp", "{ArrowUp}"],
+  ])("opens with %s and focuses the current language", async (_name, key) => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.tab();
+    await user.tab();
+    expect(trigger()).toHaveFocus();
+
+    await user.keyboard(key);
+
+    expect(trigger()).toHaveAttribute("aria-expanded", "true");
+    expect(option(/Español/)).toHaveFocus();
+    expectNoSelection();
+  });
+
+  it("moves through languages with arrows, Home and End without selecting", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(trigger());
+
+    await user.keyboard("{ArrowDown}");
+    expect(option(/Français/)).toHaveFocus();
+    await user.keyboard("{ArrowUp}");
+    expect(option(/Español/)).toHaveFocus();
+    await user.keyboard("{Home}");
+    expect(option(/English/)).toHaveFocus();
+    await user.keyboard("{End}");
+    expect(option(/日本語/)).toHaveFocus();
+
+    expect(option(/Español/)).toHaveAttribute("aria-selected", "true");
+    expect(option(/日本語/)).toHaveAttribute("aria-selected", "false");
+    expectNoSelection();
+  });
+
+  it.each([
+    ["Enter", "{Enter}"],
+    ["Space", " "],
+  ])("selects exactly once with %s and restores focus after locale changes", async (_name, key) => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(trigger());
+    await user.keyboard("{ArrowDown}");
+    expect(option(/Français/)).toHaveFocus();
+
+    await user.keyboard(key);
+
+    expect(mockSetLocale).toHaveBeenCalledTimes(1);
+    expect(mockSetLocale).toHaveBeenCalledWith("fr");
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard", { locale: "fr" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger()).toHaveAttribute("aria-expanded", "false");
+    expect(trigger()).toHaveTextContent("Français");
+    await waitFor(() => expect(trigger()).toHaveFocus());
+
+    await user.click(trigger());
+    expect(option(/Français/)).toHaveFocus();
+    expect(option(/Français/)).toHaveAttribute("aria-selected", "true");
+    expect(mockSetLocale).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["option", "trigger"])("dismisses with Escape from the %s without changing language", async (origin) => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(trigger());
+    if (origin === "trigger") trigger().focus();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger()).toHaveAttribute("aria-expanded", "false");
+    expect(trigger()).toHaveFocus();
+    expect(trigger()).toHaveTextContent("Español");
+    expectNoSelection();
+  });
+
+  it("lets Tab leave the entire picker for the following control", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(trigger());
+
+    await user.tab();
+
+    expect(screen.getByRole("button", { name: "After picker" })).toHaveFocus();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger()).toHaveAttribute("aria-expanded", "false");
+    expectNoSelection();
+  });
+
+  it("lets Shift+Tab leave the entire picker for the preceding control", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(trigger());
+
+    await user.tab({ shift: true });
+
+    expect(screen.getByRole("button", { name: "Before picker" })).toHaveFocus();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger()).toHaveAttribute("aria-expanded", "false");
+    expectNoSelection();
+  });
+
+  it("preserves pointer selection and the current pathname", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(trigger());
+
+    await user.click(option(/English/));
+
+    expect(mockSetLocale).toHaveBeenCalledTimes(1);
+    expect(mockSetLocale).toHaveBeenCalledWith("en");
+    expect(mockReplace).toHaveBeenCalledTimes(1);
+    expect(mockReplace).toHaveBeenCalledWith("/dashboard", { locale: "en" });
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger()).toHaveTextContent("English");
+    await waitFor(() => expect(trigger()).toHaveFocus());
+  });
+
+  it("dismisses an outside click without stealing the clicked control's focus", async () => {
+    const user = userEvent.setup();
+    renderPicker();
+    await user.click(trigger());
+    const outside = screen.getByRole("button", { name: "After picker" });
+
+    await user.click(outside);
+
+    expect(outside).toHaveFocus();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger()).toHaveAttribute("aria-expanded", "false");
+    expectNoSelection();
+  });
+});


### PR DESCRIPTION
Opening the header language listbox leaves focus on its trigger; arrow keys do not move between languages and Escape does not dismiss the popup. Focus now enters the current language, arrows and Home/End navigate without changing the locale, and Escape or selection restores focus to the trigger. Tab exits naturally and closes the popup on blur. Visible focus rings distinguish the active control.

The language list, translations and URL-based locale navigation from #633 are preserved. Pointer selection and outside-click dismissal remain covered.

Validation:
- 15 focused interaction tests pass; the unchanged component passes 2 and fails 13.
- Full Jest suite: 145 tests in 15 suites pass, run serially.
- Whitespace checks pass. Public-site keyboard checks confirmed the original arrow/Escape behavior.

Tests exercise the real component with stateful locale and router mocks, including focus restoration after the locale changes. Implementation and tests were prepared with AI assistance and reviewed independently by a separate AI agent.
