### PR TITLE
Show desktop nav and article chrome from 1280px

### DIFF
--- a/src/components/MdxContainer.tsx
+++ b/src/components/MdxContainer.tsx
@@ -79,18 +79,18 @@ export default async function MdxContainer({
         id="content"
         className={`container m-auto flex h-auto flex-col space-y-5 px-2 pt-5 ${
           hasSideMenu && roots && roots.length > 0
-            ? "xl:flex-row xl:space-x-12"
-            : "xl:flex-col"
+            ? "min-[1280px]:flex-row min-[1280px]:space-x-12"
+            : "min-[1280px]:flex-col"
         }`}
       >
         {hasSideMenu && (
-          <div className="relative w-auto xl:w-2/5">{sideMenu}</div>
+          <div className="relative w-auto min-[1280px]:w-2/5">{sideMenu}</div>
         )}
         {isResearchArticle && researchMeta ? (
-          <div className="flex min-w-0 flex-1 flex-col gap-10 lg:gap-12 xl:flex-row xl:items-start">
+          <div className="flex min-w-0 flex-1 flex-col gap-10 lg:gap-12 min-[1280px]:flex-row min-[1280px]:items-start">
             <section
               style={{ margin: "auto" }}
-              className="h-auto w-full border-t p-3 dark:border-slate-400 xl:flex-1 xl:border-l"
+              className="h-auto w-full border-t p-3 dark:border-slate-400 min-[1280px]:flex-1 min-[1280px]:border-l"
             >
               <nav
                 className="mb-6 text-xs font-medium text-muted-foreground"
@@ -137,7 +137,7 @@ export default async function MdxContainer({
           <section
             style={{ margin: "auto" }}
             className={`h-auto w-full p-3 dark:border-slate-400 ${
-              hasSideMenu ? "xl:border-l" : ""
+              hasSideMenu ? "min-[1280px]:border-l" : ""
             }`}
           >
             {breadcrumbs ? <Breadcrumbs items={breadcrumbs} /> : null}

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -500,7 +500,7 @@ const MoreRow = ({
   return (
     <div
       id="nav-more-row"
-      className="hidden xl:flex flex-wrap items-center gap-x-5 gap-y-2 pt-2 pb-3 border-t border-slate-300 dark:border-slate-600"
+      className="hidden min-[1280px]:flex flex-wrap items-center gap-x-5 gap-y-2 pt-2 pb-3 border-t border-slate-300 dark:border-slate-600"
     >
       {entries.map((entry) => (
         <Link
@@ -547,7 +547,7 @@ const NavLinks = ({
   return (
     <div className={`flex items-center ${classes}`}>
       {/* Large screens */}
-      <div className="hidden lg:flex items-center space-x-10">
+      <div className="hidden lg:flex items-center space-x-5 xl:space-x-10">
         {navigations.slice(0, 4).map((item, i) =>
           item.links ? (
             <Dropdown
@@ -691,7 +691,7 @@ const NavLinks = ({
         )}
       </div>
       {/* CTA buttons */}
-      <div className="hidden md:flex items-center gap-3 ml-7 pl-7 border-l border-slate-400 dark:border-slate-600">
+      <div className="hidden md:flex items-center gap-2 xl:gap-3 ml-4 pl-4 xl:ml-7 xl:pl-7 border-l border-slate-400 dark:border-slate-600">
         <Button
           asChild
           variant="default"
@@ -962,7 +962,7 @@ const Navigation = ({ searchItems }: { searchItems: readonly Searcher[] }) => {
           <Link prefetch href="/" className="shrink-0 hover:cursor-pointer">
             <Logo theme={mounted && isDark} />
           </Link>
-          <nav className="hidden xl:flex flex-1 justify-center max-w-4xl mx-8">
+          <nav className="hidden min-[1280px]:flex flex-1 justify-center max-w-4xl mx-3 min-[1280px]:mx-4 xl:mx-8">
             <NavLinks
               classes="w-full justify-start"
               closeMenu={() => setIsOpen(false)}
@@ -999,7 +999,7 @@ const Navigation = ({ searchItems }: { searchItems: readonly Searcher[] }) => {
               )}
             </Button>
             <div
-              className="hidden xl:flex relative"
+              className="hidden min-[1280px]:flex relative"
               onMouseEnter={() => setShowShop(true)}
               onMouseLeave={() => setShowShop(false)}
             >
@@ -1023,7 +1023,7 @@ const Navigation = ({ searchItems }: { searchItems: readonly Searcher[] }) => {
             </div>
             {mounted ? (
               <Sheet open={isOpen} onOpenChange={setIsOpen}>
-                <SheetTrigger className="xl:hidden" asChild>
+                <SheetTrigger className="min-[1280px]:hidden" asChild>
                   <Button
                     variant="ghost"
                     size="sm"
@@ -1040,7 +1040,7 @@ const Navigation = ({ searchItems }: { searchItems: readonly Searcher[] }) => {
                 </SheetContent>
               </Sheet>
             ) : (
-              <div className="xl:hidden">
+              <div className="min-[1280px]:hidden">
                 <Button
                   variant="ghost"
                   size="sm"

--- a/src/components/Research/ResearchArticleAside.tsx
+++ b/src/components/Research/ResearchArticleAside.tsx
@@ -43,7 +43,7 @@ export default function ResearchArticleAside({ title, shareUrl }: Props) {
   }, [title, shareUrl]);
 
   return (
-    <aside className="w-full shrink-0 space-y-10 border-t border-slate-200 pt-8 dark:border-slate-400 xl:w-[min(100%,280px)] xl:border-t-0 xl:border-l xl:border-slate-200 xl:pl-8 xl:pt-0 dark:xl:border-slate-400">
+    <aside className="w-full shrink-0 space-y-10 border-t border-slate-200 pt-8 dark:border-slate-400 min-[1280px]:w-[min(100%,280px)] min-[1280px]:border-t-0 min-[1280px]:border-l min-[1280px]:border-slate-200 min-[1280px]:pl-8 min-[1280px]:pt-0 dark:min-[1280px]:border-slate-400">
       <div>
         <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
           Share post

--- a/src/components/SideMenu/SideMenu.tsx
+++ b/src/components/SideMenu/SideMenu.tsx
@@ -75,13 +75,13 @@ const SideMenu = ({ folder, roots, titles = {}, enTitles = {} }: MenuProps) => {
   const fold = getName(name);
 
   return (
-    <div className="relative flex flex-wrap items-center xl:items-start order-1 justify-between xl:flex-col">
-      <button onClick={toggleMenu} className="xl:hidden flex cursor-pointer">
+    <div className="relative flex flex-wrap items-center min-[1280px]:items-start order-1 justify-between min-[1280px]:flex-col">
+      <button onClick={toggleMenu} className="min-[1280px]:hidden flex cursor-pointer">
         <BurgerMenuIcon size={24} />{" "}
         <h3 className="ms-2 font-bold">{t?.sideMenu?.navigation ?? "Navigation"}</h3>
       </button>
 
-      <div className="flex justify-end xl:justify-center w-auto order-2 xl:order-3">
+      <div className="flex justify-end min-[1280px]:justify-center w-auto order-2 min-[1280px]:order-3">
         <Link
           href="/explore"
           className="flex items-center rounded-full font-bold px-4 py-2 hover:bg-[#1984c7]"
@@ -98,8 +98,8 @@ const SideMenu = ({ folder, roots, titles = {}, enTitles = {} }: MenuProps) => {
       </div>
 
       <div
-        className={`flex flex-col shrink-0 top-0 py-4 xl:items-center justify-start w-full px-3 order-3 xl:order-2 ${
-          isMenuOpen ? "block mt-7" : "hidden xl:block"
+        className={`flex flex-col shrink-0 top-0 py-4 min-[1280px]:items-center justify-start w-full px-3 order-3 min-[1280px]:order-2 ${
+          isMenuOpen ? "block mt-7" : "hidden min-[1280px]:block"
         }`}
       >
         <h1 className="text-4xl font-bold mb-6"> {chromeLabel(fold)}: </h1>


### PR DESCRIPTION
## Summary

The project's `xl` breakpoint is 1530px. At 100% zoom on a typical laptop (about 1280 to 1512 CSS pixels) the wiki still used the hamburger and a stacked article. Reviewers had to drop to 90% to see the real desktop chrome.

I switched nav, article, SideMenu, and the research aside at `min-[1280px]`. I did not change the global `xl` token in `tailwind.config.ts`. Icon spacing that already used `xl:` for a wide desktop still uses 1530px.

This pull request does not add live heroes or org-banner assets. The banner work is a separate PR: https://github.com/ZecHub/zechub-wiki/pull/802

The two branches merge cleanly in either order onto current `main`.

Fixes #805

## Screenshots

Faucets at 1279. Hamburger and stacked article, as intended:

![Faucets at 1279 with hamburger](https://raw.githubusercontent.com/CodeMongerrr/zechub-wiki/pr-assets/wiki-split-2026-09/layout-faucets-1279.png)

Faucets at 1280. Full desktop nav: Use Zcash, Ecosystem, Guides, Organizations, More, Bounties, Dashboard, Donate:

![Faucets at 1280 with desktop nav](https://raw.githubusercontent.com/CodeMongerrr/zechub-wiki/pr-assets/wiki-split-2026-09/layout-faucets-1280.png)

Organizations at 1279 vs 1280. Same page; the article and sidebar join a row at 1280:

![Organizations stacked at 1279](https://raw.githubusercontent.com/CodeMongerrr/zechub-wiki/pr-assets/wiki-split-2026-09/layout-orgs-1279-stack.png)

![Organizations row at 1280](https://raw.githubusercontent.com/CodeMongerrr/zechub-wiki/pr-assets/wiki-split-2026-09/layout-orgs-1280-row.png)

1440 and 1512 stay on desktop chrome. 390 stays on the hamburger:

![Faucets at 1440](https://raw.githubusercontent.com/CodeMongerrr/zechub-wiki/pr-assets/wiki-split-2026-09/layout-faucets-1440.png)

![Faucets at 1512](https://raw.githubusercontent.com/CodeMongerrr/zechub-wiki/pr-assets/wiki-split-2026-09/layout-faucets-1512.png)

![Faucets at 390](https://raw.githubusercontent.com/CodeMongerrr/zechub-wiki/pr-assets/wiki-split-2026-09/layout-faucets-390.png)

## Test plan

- [ ] `/using-zcash/faucets` at 1279: hamburger, stacked Navigation, no desktop link row
- [ ] Same page at 1280: Use Zcash, Ecosystem, Guides, Organizations, More, Bounties, Dashboard, Donate; article and sidebar in a row
- [ ] Same page at 1440 and ~1512: still desktop chrome
- [ ] Same page at 390: hamburger and stacked article
- [ ] Organizations or another sidebar page: same 1279 / 1280 split
- [ ] Confirm `tailwind.config.ts` still has `xl: "1530px"`
- [ ] Confirm this branch has no WikiSectionBanner / liveHero / org-banner changes


Made with [Cursor](https://cursor.com)