### PR TITLE
security: harden markdown AST sanitizer against HTML injection and enforce Content-Security-Policy

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -73,13 +73,12 @@ const nextConfig = {
     //     still runs. Treat XSS via a sanitizer/nonce as separate follow-up work.
     //   * Preview deploys inject the vercel.live toolbar (violates script/connect/
     //     frame) — monitor a PRODUCTION deploy, or filter those out.
-    // To ENFORCE: rename the header to "Content-Security-Policy" (+ /embed carve-out).
-    const cspReportOnly = [
+    // Enforced Content-Security-Policy with /embed carve-out for framing
+    const baseCspDirectives = [
       "default-src 'self'",
       "base-uri 'self'",
       "object-src 'none'",
       "form-action 'self'",
-      "frame-ancestors 'self'",
       "script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'",
       "style-src 'self' 'unsafe-inline'",
       "img-src 'self' data: blob: https://i.ytimg.com https://i.postimg.cc https://*.basemaps.cartocdn.com https://img.shields.io https://upload.wikimedia.org https://ipfs.daodao.zone",
@@ -94,6 +93,16 @@ const nextConfig = {
       "manifest-src 'self'",
       "report-uri /api/csp-report",
       "report-to csp-endpoint",
+    ];
+
+    const cspEnforced = [
+      ...baseCspDirectives,
+      "frame-ancestors 'self'",
+    ].join("; ");
+
+    const cspEmbed = [
+      ...baseCspDirectives,
+      "frame-ancestors *",
     ].join("; ");
 
     const baseline = [
@@ -119,21 +128,26 @@ const nextConfig = {
         key: "Strict-Transport-Security",
         value: "max-age=63072000; includeSubDomains; preload",
       },
-      // Report-only CSP (policy built above). Blocks nothing yet — reports
-      // violations to the console and to /api/csp-report so we can watch a
-      // preview before flipping to the enforcing "Content-Security-Policy".
-      { key: "Content-Security-Policy-Report-Only", value: cspReportOnly },
       // Declares the endpoint named by the report-to directive (Reporting API).
       { key: "Reporting-Endpoints", value: 'csp-endpoint="/api/csp-report"' },
     ];
     return [
       { source: "/:path*", headers: baseline },
       {
-        // Clickjacking protection everywhere EXCEPT the embeddable widget under
-        // /embed (and its locale-prefixed form /xx/embed), which is designed to
-        // be framed by third-party sites.
+        // Enforce Content-Security-Policy & clickjacking protection everywhere
+        // EXCEPT the embeddable widget under /embed, which is framed by third parties.
         source: "/((?!(?:[a-z]{2}/)?embed(?:/|$)).*)",
-        headers: [{ key: "X-Frame-Options", value: "DENY" }],
+        headers: [
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Content-Security-Policy", value: cspEnforced },
+        ],
+      },
+      {
+        // Embed routes allow framing from any origin with enforced CSP
+        source: "/((?:[a-z]{2}/)?embed(?:/.*)?)",
+        headers: [
+          { key: "Content-Security-Policy", value: cspEmbed },
+        ],
       },
     ];
   },

--- a/src/app/[locale]/[...slug]/page.tsx
+++ b/src/app/[locale]/[...slug]/page.tsx
@@ -45,22 +45,43 @@ import rehypeRaw from "rehype-raw";
 import { visit, SKIP } from "unist-util-visit";
 
 // Defense-in-depth: content markdown is rendered via rehypeRaw (raw HTML
-// passthrough) with no allow-list sanitizer, so a malicious content-repo change
-// could otherwise inject executable markup. Strip the direct XSS vectors —
-// <script>/<style> elements, on* event-handler attributes, and javascript: URLs.
-// (A full allow-list sanitizer or nonce-based CSP is the complete fix; this
-// closes the obvious holes without risking removal of legitimate content HTML.)
+// passthrough). Strip dangerous elements (<script>, <style>, <object>, <embed>,
+// <base>, <meta>, <link>, <applet>), untrusted iframes (allowing only YouTube embeds),
+// on* event-handler attributes, javascript:/vbscript: URLs, and unsafe data: URIs.
 function rehypeStripDangerous() {
+  const dangerousTags = new Set([
+    "script",
+    "style",
+    "object",
+    "embed",
+    "base",
+    "meta",
+    "link",
+    "applet",
+  ]);
+
   return (tree: any) => {
     (visit as any)(tree, "element", (node: any, index: number | undefined, parent: any) => {
-      if (
-        (node.tagName === "script" || node.tagName === "style") &&
-        parent &&
-        typeof index === "number"
-      ) {
+      const tag = (node.tagName || "").toLowerCase();
+
+      // Remove dangerous executable/injection elements
+      if (dangerousTags.has(tag) && parent && typeof index === "number") {
         parent.children.splice(index, 1);
         return [SKIP, index];
       }
+
+      // Restrict iframes to trusted YouTube video embeds
+      if (tag === "iframe" && parent && typeof index === "number") {
+        const src = String(node.properties?.src || "").toLowerCase();
+        const isTrusted =
+          src.startsWith("https://www.youtube.com/") ||
+          src.startsWith("https://www.youtube-nocookie.com/");
+        if (!isTrusted) {
+          parent.children.splice(index, 1);
+          return [SKIP, index];
+        }
+      }
+
       const props = node.properties || {};
       for (const key of Object.keys(props)) {
         const k = key.toLowerCase();
@@ -70,14 +91,17 @@ function rehypeStripDangerous() {
           delete props[key];
           continue;
         }
-        // Script-executing URL schemes on any URL-bearing attribute.
+        // Script-executing URL schemes and unsafe data URIs on URL-bearing attributes.
         const v = props[key];
         if (
-          ["href", "src", "xlinkhref", "action", "poster"].includes(k) &&
-          typeof v === "string" &&
-          /^\s*(javascript|vbscript):/i.test(v)
+          ["href", "src", "xlinkhref", "action", "poster", "data"].includes(k) &&
+          typeof v === "string"
         ) {
-          delete props[key];
+          if (/^\s*(javascript|vbscript):/i.test(v)) {
+            delete props[key];
+          } else if (/^\s*data:/i.test(v) && !/^\s*data:image\//i.test(v)) {
+            delete props[key];
+          }
         }
       }
     });


### PR DESCRIPTION
Resolves ZecHub Bounty ID: `cmtwgyds8000tcvpc30esrqpp` ("Content markdown is rendered with raw-HTML passthrough behind a bypassable blocklist sanitizer, while CSP is report-only (non-enforcing)")

@ZecHub/bounties cmtwgyds8000tcvpc30esrqpp – submission for bounty.

### Summary of Changes

1. **Hardened Markdown AST Sanitizer (`src/app/[locale]/[...slug]/page.tsx`):**
   - Expanded element filtering to strip executable/injection vectors: `object`, `embed`, `base`, `meta`, `link`, and `applet`.
   - Restricted `<iframe>` rendering strictly to trusted YouTube domains (`https://www.youtube.com/` and `https://www.youtube-nocookie.com/`), dropping untrusted iframe injections.
   - Added `data` attribute inspection to URL-bearing property checks.
   - Disallowed dangerous `data:` URI schemes across all URL-bearing attributes while preserving valid inline images (`data:image/`).

2. **Enforced Content Security Policy (`next.config.mjs`):**
   - Transitioned from `Content-Security-Policy-Report-Only` to active `Content-Security-Policy` enforcement.
   - Implemented an `/embed` route carveout allowing `frame-ancestors *` for third-party widget embedding while enforcing `frame-ancestors 'self'` and `X-Frame-Options: DENY` across all standard wiki pages.