### PR TITLE
fix(payment-request): validate ZIP-321 payment requests across builder, widget, and QR API

### DIFF
--- a/src/app/[locale]/tools/PaymentRequestBuilder.tsx
+++ b/src/app/[locale]/tools/PaymentRequestBuilder.tsx
@@ -9,9 +9,17 @@ import {
   useRef,
   useState,
 } from "react";
-import { detectZcashNetwork, encodeMemo, type ZcashNetwork } from "./helper";
+import { detectZcashNetwork, type ZcashNetwork } from "./helper";
 import { useWasm } from "./hooks/useWasm";
 import WasmInitStatus from "./WasmInitStatus";
+import {
+  buildZip321Uri,
+  formatZecAmount,
+  isShieldedAddress,
+  isTransparentAddress,
+  validateZip321Payment,
+  MAX_MEMO_BYTES,
+} from "@/lib/zip321";
 
 function QRCode({ value, size = 176 }: { value: string; size?: number }) {
   return (
@@ -167,35 +175,34 @@ export default function PaymentRequestBuilder() {
 
   const allValid =
     payments.length > 0 &&
-    payments.every((p) => p.validation.status === "valid");
+    payments.every((p) => {
+      if (p.validation.status !== "valid") return false;
+      const v = validateZip321Payment({
+        address: p.address,
+        amount: p.amount || undefined,
+        memo: p.memo || undefined,
+        label: p.label || undefined,
+        message: p.message || undefined,
+      });
+      return v.valid;
+    });
 
   const uri = useMemo(() => {
     if (!allValid) return null;
 
-    const parts: string[] = [];
-
-    payments.forEach((p, i) => {
-      const idx = i === 0 ? "" : `.${i}`;
-
-      parts.push(`address${idx}=${p.address}`);
-      if (p.amount) parts.push(`amount${idx}=${p.amount}`);
-      if (p.label) parts.push(`label${idx}=${encodeURIComponent(p.label)}`);
-      if (p.message)
-        parts.push(`message${idx}=${encodeURIComponent(p.message)}`);
-
-      const isShielded =
-        p.address.startsWith("zs") ||
-        p.address.startsWith("u1") ||
-        p.address.startsWith("utest1");
-
-      if (p.memo && isShielded) {
-        const m = encodeMemo(p.memo);
-
-        if (m) parts.push(`memo${idx}=${m}`);
-      }
-    });
-
-    return `zcash:?${parts.join("&")}`;
+    try {
+      return buildZip321Uri(
+        payments.map((p) => ({
+          address: p.address,
+          amount: p.amount || undefined,
+          label: p.label || undefined,
+          message: p.message || undefined,
+          memo: p.memo || undefined,
+        })),
+      );
+    } catch {
+      return null;
+    }
   }, [payments, allValid]);
 
   const deferredURI = useDeferredValue(uri);
@@ -265,10 +272,7 @@ export default function PaymentRequestBuilder() {
           const v = p.validation;
 
           const isValid = p.validation.status === "valid";
-          const isShielded =
-            p.address.startsWith("zs") ||
-            p.address.startsWith("u1") ||
-            p.address.startsWith("utest1");
+          const isShielded = isShieldedAddress(p.address);
 
           return (
             <div
@@ -368,6 +372,18 @@ export default function PaymentRequestBuilder() {
                         step="any"
                         min="0"
                       />
+                      {p.amount && (() => {
+                        try {
+                          formatZecAmount(p.amount);
+                          return null;
+                        } catch (err) {
+                          return (
+                            <p className="mt-1 ml-1 text-[11px] text-red-500 font-medium">
+                              {err instanceof Error ? err.message : "Invalid amount"}
+                            </p>
+                          );
+                        }
+                      })()}
                     </div>
                     <div>
                       <label className={LABEL_CLASS}>Label</label>
@@ -400,9 +416,24 @@ export default function PaymentRequestBuilder() {
                   </div>
 
                   {/* Memo — shielded only */}
-                  {isShielded && (
+                  {isShielded ? (
                     <div>
-                      <label className={LABEL_CLASS}>Encrypted Memo</label>
+                      <div className="flex justify-between items-center mb-1.5 ml-1">
+                        <label className="text-[11px] font-semibold uppercase tracking-[0.1em] text-zinc-400 dark:text-[#5a6a7e]">
+                          Encrypted Memo
+                        </label>
+                        <span
+                          className={`text-[10px] font-mono ${
+                            new TextEncoder().encode(p.memo || "").length >
+                            MAX_MEMO_BYTES
+                              ? "text-red-500 font-bold"
+                              : "text-zinc-400 dark:text-[#5a6a7e]"
+                          }`}
+                        >
+                          {new TextEncoder().encode(p.memo || "").length}/
+                          {MAX_MEMO_BYTES} bytes
+                        </span>
+                      </div>
                       <textarea
                         disabled={!isValid}
                         value={p.memo}
@@ -413,11 +444,23 @@ export default function PaymentRequestBuilder() {
                         rows={3}
                         className={`${INPUT_CLASS} resize-y font-mono text-sm min-h-[72px]`}
                       />
+                      {new TextEncoder().encode(p.memo || "").length >
+                        MAX_MEMO_BYTES && (
+                        <p className="mt-1 ml-1 text-[11px] text-red-500 font-medium">
+                          Memo exceeds maximum 512-byte limit (ZIP 321).
+                        </p>
+                      )}
                       <p className="mt-1 ml-1 text-[10px] font-mono text-[#3d4e60]">
                         Encoded as base64url per ZIP-321
                       </p>
                     </div>
-                  )}
+                  ) : p.address && isTransparentAddress(p.address) && p.memo ? (
+                    <div className="mt-2 rounded-xl bg-amber-500/10 border border-amber-500/20 px-4 py-3">
+                      <p className="text-[13px] text-amber-500 font-medium">
+                        Memos are not supported for transparent addresses in ZIP 321.
+                      </p>
+                    </div>
+                  ) : null}
 
                   {payments.length > 1 && (
                     <div className="my-4">

--- a/src/app/[locale]/tools/zcash-payment-widget/PaymentRequestWidget.tsx
+++ b/src/app/[locale]/tools/zcash-payment-widget/PaymentRequestWidget.tsx
@@ -12,6 +12,7 @@ import { GeneratedConfig } from "../ToolTabs";
 import WasmInitStatus from "../WasmInitStatus";
 import WidgetButtonTrigger from "./WidgetButtonTrigger";
 import { config } from "./config";
+import { formatZecAmount, isShieldedAddress } from "@/lib/zip321";
 
 const INPUT_CLASS = [
   "w-full bg-zinc-50 dark:bg-[#0f1720] border border-zinc-200 dark:border-[#243040]",
@@ -128,9 +129,22 @@ export default function PaymentRequestWidget() {
   // Flags
   const isLoading = payment.validation.status === "validating";
 
+  const isAmountValid = (() => {
+    if (!payment.amount || parseFloat(payment.amount) <= 0) return false;
+    if (currency === "zec") {
+      try {
+        formatZecAmount(payment.amount);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  })();
+
   const allValid =
     payment.address !== "" &&
-    parseFloat(payment.amount) > 0 &&
+    isAmountValid &&
     payment.validation.status === "valid";
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -175,7 +189,7 @@ export default function PaymentRequestWidget() {
         zecUsdRate: data.rate,
         label: payment.label,
         address: payment.address,
-        disabled: data.amount < 0,
+        disabled: data.amount <= 0,
         apiBase: WIDGET_API_BASE_URL,
         validation: payment.validation,
         target: config.ZCASH_PAYMENT_WIDGET_TARGET
@@ -189,10 +203,7 @@ export default function PaymentRequestWidget() {
   };
 
   const isValid = payment.validation.status === "valid";
-  const isShielded =
-    payment.address.startsWith("zs") ||
-    payment.address.startsWith("u1") ||
-    payment.address.startsWith("utest1");
+  const isShielded = isShieldedAddress(payment.address);
 
   useEffect(() => {
     if (!payment.address) return;
@@ -324,6 +335,18 @@ export default function PaymentRequestWidget() {
                   step="any"
                   min="0"
                 />
+                {currency === "zec" && payment.amount && (() => {
+                  try {
+                    formatZecAmount(payment.amount);
+                    return null;
+                  } catch (err) {
+                    return (
+                      <p className="mt-1 ml-1 text-[11px] text-red-500 font-medium">
+                        {err instanceof Error ? err.message : "Invalid amount"}
+                      </p>
+                    );
+                  }
+                })()}
               </div>
 
               <div>

--- a/src/app/[locale]/tools/zcash-payment-widget/adapters/helpers/index.ts
+++ b/src/app/[locale]/tools/zcash-payment-widget/adapters/helpers/index.ts
@@ -41,7 +41,7 @@ export function loadZcashPaymentUriWidget(src: string): Promise<void> {
 async function loadWithRetry(loader: any, retries = 2, delay = 1000) {
   let lastError;
 
-  for (let i = 0; (i = retries); i++) {
+  for (let i = 0; i <= retries; i++) {
     try {
       return await loader();
     } catch (err) {

--- a/src/app/api/payment-request-uri/qrcode/route.ts
+++ b/src/app/api/payment-request-uri/qrcode/route.ts
@@ -2,6 +2,7 @@ import { is_valid_zcash_address } from "@elemental-zcash/zaddr_wasm_parser";
 import { NextRequest, NextResponse } from "next/server";
 import QRCode from "qrcode";
 import { qrCodeBodySchema } from "./schema/qrcode.schema";
+import { buildZip321Uri, validateZip321Payment } from "@/lib/zip321";
 
 export async function GET(req: NextRequest) {
   const data = req.nextUrl.searchParams.get("data");
@@ -17,7 +18,6 @@ export async function GET(req: NextRequest) {
       margin: 1,
       scale: 10,
       width: dim ? parseInt(dim) : 240,
-
     });
     const base64 = qrCode.split(",")[1];
     const buffer = Buffer.from(base64, "base64");
@@ -31,9 +31,9 @@ export async function GET(req: NextRequest) {
     });
   } catch (err) {
     console.error(err);
-    
+
     return NextResponse.json(
-      { error: '"Failed to generate QR code"' },
+      { error: "Failed to generate QR code" },
       { status: 500 },
     );
   }
@@ -43,7 +43,15 @@ export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
 
-    const { amount, address, label, memo } = qrCodeBodySchema.parse(body);
+    const parsed = qrCodeBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: parsed.error.issues[0]?.message || "Invalid request payload" },
+        { status: 400 },
+      );
+    }
+
+    const { amount, address, label, message, memo } = parsed.data;
 
     if (!is_valid_zcash_address(address)) {
       return NextResponse.json(
@@ -52,26 +60,38 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // Zcash URI format: zcash:<address>?amount=1.23&memo=...
-    let uri = `zcash:${address}`;
-    const params = new URLSearchParams();
+    const validation = validateZip321Payment({
+      address,
+      amount,
+      label,
+      message,
+      memo,
+    });
 
-    if (amount) params.append("amount", amount.toString());
-    if (label) params.append("label", label);
-    if (memo) params.append("memo", memo);
-
-    const paramsStr = params.toString();
-    if (paramsStr) {
-      uri += `?${paramsStr}`;
+    if (!validation.valid) {
+      return NextResponse.json(
+        { error: validation.error },
+        { status: 400 },
+      );
     }
+
+    const uri = buildZip321Uri([
+      {
+        address,
+        amount,
+        label,
+        message,
+        memo,
+      },
+    ]);
 
     const qrData = await QRCode.toDataURL(uri, { margin: 1, scale: 6 });
 
     return NextResponse.json({ data: { uri, qrData } }, { status: 200 });
   } catch (err) {
-    const msg =
-      err instanceof Error ? err.message : "Failed process payment uri.";
+    const errorMsg =
+      err instanceof Error ? err.message : "Failed to process payment URI.";
 
-    return NextResponse.json({ error: JSON.parse(msg) }, { status: 500 });
+    return NextResponse.json({ error: errorMsg }, { status: 500 });
   }
 }

--- a/src/app/api/payment-request-uri/qrcode/schema/qrcode.schema.ts
+++ b/src/app/api/payment-request-uri/qrcode/schema/qrcode.schema.ts
@@ -1,8 +1,10 @@
 import { z } from "zod";
 
 export const qrCodeBodySchema = z.object({
-  address: z.string(),
-  amount: z.number().optional(),
-  label: z.string(),
+  address: z.string().min(1, "Address is required"),
+  amount: z.union([z.number(), z.string()]).optional(),
+  label: z.string().optional(),
+  message: z.string().optional(),
   memo: z.string().optional(),
 });
+

--- a/src/lib/__tests__/zip321.test.ts
+++ b/src/lib/__tests__/zip321.test.ts
@@ -1,0 +1,265 @@
+import {
+  MAX_MEMO_BYTES,
+  MAX_ZEC_SUPPLY,
+  buildZip321Uri,
+  decodeZip321Memo,
+  encodeZip321Memo,
+  formatZecAmount,
+  isShieldedAddress,
+  isTransparentAddress,
+  parseZip321Uri,
+  validateZip321Payment,
+} from "../zip321";
+
+describe("ZIP-321 Amount Boundaries & Formatting", () => {
+  it("formats valid standard amounts preserving decimal precision", () => {
+    expect(formatZecAmount("1")).toBe("1");
+    expect(formatZecAmount("1.5")).toBe("1.5");
+    expect(formatZecAmount(1.5)).toBe("1.5");
+    expect(formatZecAmount("0.12345678")).toBe("0.12345678");
+    expect(formatZecAmount("21000000")).toBe("21000000");
+  });
+
+  it("normalizes trailing and leading zeroes correctly", () => {
+    expect(formatZecAmount("1.50000000")).toBe("1.5");
+    expect(formatZecAmount("2.00000000")).toBe("2");
+    expect(formatZecAmount("01.5")).toBe("1.5");
+  });
+
+  it("correctly handles one zatoshi and scientific notation without emitting '1e-8'", () => {
+    expect(formatZecAmount(0.00000001)).toBe("0.00000001");
+    expect(formatZecAmount(1e-8)).toBe("0.00000001");
+    expect(formatZecAmount("1e-8")).toBe("0.00000001");
+    expect(formatZecAmount("0.00000001")).toBe("0.00000001");
+  });
+
+  it("rejects amounts exceeding 8 decimal places (zatoshi precision)", () => {
+    expect(() => formatZecAmount("0.123456789")).toThrow(
+      /exceeds maximum 8 decimal places/i,
+    );
+    expect(() => formatZecAmount("0.000000001")).toThrow(
+      /exceeds maximum 8 decimal places/i,
+    );
+  });
+
+  it("rejects zero and negative amounts", () => {
+    expect(() => formatZecAmount(0)).toThrow(/greater than zero/i);
+    expect(() => formatZecAmount("0")).toThrow(/greater than zero/i);
+    expect(() => formatZecAmount("0.00000000")).toThrow(/greater than zero/i);
+    expect(() => formatZecAmount(-1)).toThrow(/greater than zero/i);
+    expect(() => formatZecAmount("-0.5")).toThrow(/must be a positive decimal number/i);
+  });
+
+  it("rejects amounts exceeding maximum ZEC supply (21,000,000)", () => {
+    expect(() => formatZecAmount(21000001)).toThrow(/exceeds maximum ZEC supply/i);
+    expect(() => formatZecAmount("21000000.00000001")).toThrow(
+      /exceeds maximum ZEC supply/i,
+    );
+  });
+
+  it("rejects non-numeric amount strings", () => {
+    expect(() => formatZecAmount("abc")).toThrow(/must be a positive decimal number/i);
+    expect(() => formatZecAmount("")).toThrow(/Amount is required/i);
+  });
+});
+
+describe("ZIP-321 Address Types & Memo Restrictions", () => {
+  const transparentT1 = "t1VpMigELggqi6TBghQNehqspAcBBDYvRQC";
+  const transparentT3 = "t3VzFdEkhttkgfp2hkEvihnc8v5K8p8q35B";
+  const shieldedSapling =
+    "zs1znewaqucqpc372x6ajmfnmkmxsafnc3fuxmg6g5kq3mkvkv8ufx9hgx9vgcrqncqm3umz56a7pd";
+  const shieldedUnified =
+    "u1p0906hsww2yq77l249qj4swj72n9q3t0a6k9d7a2y29g9mptfsq6f77q7c4v7p2p0n8x9f36h4j";
+
+  it("distinguishes transparent and shielded addresses", () => {
+    expect(isTransparentAddress(transparentT1)).toBe(true);
+    expect(isTransparentAddress(transparentT3)).toBe(true);
+    expect(isTransparentAddress(shieldedSapling)).toBe(false);
+    expect(isTransparentAddress(shieldedUnified)).toBe(false);
+
+    expect(isShieldedAddress(shieldedSapling)).toBe(true);
+    expect(isShieldedAddress(shieldedUnified)).toBe(true);
+    expect(isShieldedAddress(transparentT1)).toBe(false);
+  });
+
+  it("strictly rejects memos attached to transparent addresses", () => {
+    expect(() => encodeZip321Memo("Invoice payment", transparentT1)).toThrow(
+      /Memos are not supported for transparent addresses in ZIP 321/i,
+    );
+    expect(() => encodeZip321Memo("Test memo", transparentT3)).toThrow(
+      /Memos are not supported for transparent addresses in ZIP 321/i,
+    );
+
+    const validation = validateZip321Payment({
+      address: transparentT1,
+      memo: "Transparent memo attempt",
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toMatch(/transparent addresses/i);
+  });
+
+  it("allows memos on shielded addresses", () => {
+    expect(() => encodeZip321Memo("Shielded payment", shieldedSapling)).not.toThrow();
+    const validation = validateZip321Payment({
+      address: shieldedSapling,
+      amount: "1.25",
+      memo: "Valid shielded payment",
+    });
+    expect(validation.valid).toBe(true);
+  });
+});
+
+describe("ZIP-321 Memo Byte Limits & Unicode Encoding", () => {
+  it("encodes and decodes ASCII memos using base64url without '=' padding", () => {
+    const memo = "Thanks for the coffee!";
+    const encoded = encodeZip321Memo(memo);
+    expect(encoded).not.toContain("=");
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(decodeZip321Memo(encoded)).toBe(memo);
+  });
+
+  it("correctly preserves multi-byte Unicode characters and emojis", () => {
+    const unicodeMemo = "🛡️ Zcash Privacy 🔐 - ありがとうございます - Café €100";
+    const encoded = encodeZip321Memo(unicodeMemo);
+    expect(encoded).not.toContain("=");
+    expect(decodeZip321Memo(encoded)).toBe(unicodeMemo);
+  });
+
+  it("accepts exactly 512 UTF-8 bytes", () => {
+    const exact512 = "A".repeat(MAX_MEMO_BYTES);
+    expect(new TextEncoder().encode(exact512).length).toBe(512);
+    const encoded = encodeZip321Memo(exact512);
+    expect(decodeZip321Memo(encoded)).toBe(exact512);
+  });
+
+  it("rejects memos exceeding 512 UTF-8 bytes", () => {
+    const tooLong = "A".repeat(MAX_MEMO_BYTES + 1);
+    expect(() => encodeZip321Memo(tooLong)).toThrow(/exceeds 512-byte limit/i);
+
+    const validation = validateZip321Payment({
+      address:
+        "zs1znewaqucqpc372x6ajmfnmkmxsafnc3fuxmg6g5kq3mkvkv8ufx9hgx9vgcrqncqm3umz56a7pd",
+      memo: tooLong,
+    });
+    expect(validation.valid).toBe(false);
+    expect(validation.error).toMatch(/exceeds 512-byte limit/i);
+  });
+
+  it("calculates byte length for multi-byte characters accurately", () => {
+    // '€' is 3 UTF-8 bytes. 170 * 3 = 510 bytes (valid). 171 * 3 = 513 bytes (invalid).
+    const validEuro = "€".repeat(170);
+    expect(new TextEncoder().encode(validEuro).length).toBe(510);
+    expect(() => encodeZip321Memo(validEuro)).not.toThrow();
+
+    const invalidEuro = "€".repeat(171);
+    expect(new TextEncoder().encode(invalidEuro).length).toBe(513);
+    expect(() => encodeZip321Memo(invalidEuro)).toThrow(/exceeds 512-byte limit/i);
+  });
+});
+
+describe("ZIP-321 URI Generation & Parsing (Single and Multi-recipient)", () => {
+  const sapling1 =
+    "zs1znewaqucqpc372x6ajmfnmkmxsafnc3fuxmg6g5kq3mkvkv8ufx9hgx9vgcrqncqm3umz56a7pd";
+  const sapling2 =
+    "zs1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqp9h7z8";
+  const transparent1 = "t1VpMigELggqi6TBghQNehqspAcBBDYvRQC";
+
+  it("builds and parses a standard single-recipient URI", () => {
+    const uri = buildZip321Uri([
+      {
+        address: sapling1,
+        amount: "0.5",
+        memo: "Coffee payment",
+        label: "Alice",
+        message: "Order #1234",
+      },
+    ]);
+
+    expect(uri.startsWith(`zcash:${sapling1}?`)).toBe(true);
+    expect(uri).toContain("amount=0.5");
+    expect(uri).toContain("label=Alice");
+
+    const parsed = parseZip321Uri(uri);
+    expect(parsed.length).toBe(1);
+    expect(parsed[0].address).toBe(sapling1);
+    expect(parsed[0].amount).toBe("0.5");
+    expect(parsed[0].memo).toBe("Coffee payment");
+    expect(parsed[0].label).toBe("Alice");
+    expect(parsed[0].message).toBe("Order #1234");
+  });
+
+  it("builds a single recipient transparent URI without memo", () => {
+    const uri = buildZip321Uri([
+      {
+        address: transparent1,
+        amount: "10",
+        label: "Exchange",
+      },
+    ]);
+
+    expect(uri).toBe(`zcash:${transparent1}?amount=10&label=Exchange`);
+    const parsed = parseZip321Uri(uri);
+    expect(parsed[0].address).toBe(transparent1);
+    expect(parsed[0].amount).toBe("10");
+    expect(parsed[0].memo).toBeUndefined();
+  });
+
+  it("builds and parses multi-recipient payment requests with indexed parameters", () => {
+    const payments = [
+      {
+        address: sapling1,
+        amount: "0.25",
+        memo: "Split 1",
+      },
+      {
+        address: sapling2,
+        amount: "0.75",
+        memo: "Split 2",
+      },
+      {
+        address: transparent1,
+        amount: "1.5",
+      },
+    ];
+
+    const uri = buildZip321Uri(payments);
+    expect(uri.startsWith("zcash:?")).toBe(true);
+    expect(uri).toContain(`address=${encodeURIComponent(sapling1)}`);
+    expect(uri).toContain("amount=0.25");
+    expect(uri).toContain(`address.1=${encodeURIComponent(sapling2)}`);
+    expect(uri).toContain("amount.1=0.75");
+    expect(uri).toContain(`address.2=${encodeURIComponent(transparent1)}`);
+    expect(uri).toContain("amount.2=1.5");
+
+    const parsed = parseZip321Uri(uri);
+    expect(parsed.length).toBe(3);
+    expect(parsed[0].address).toBe(sapling1);
+    expect(parsed[0].amount).toBe("0.25");
+    expect(parsed[0].memo).toBe("Split 1");
+
+    expect(parsed[1].address).toBe(sapling2);
+    expect(parsed[1].amount).toBe("0.75");
+    expect(parsed[1].memo).toBe("Split 2");
+
+    expect(parsed[2].address).toBe(transparent1);
+    expect(parsed[2].amount).toBe("1.5");
+    expect(parsed[2].memo).toBeUndefined();
+  });
+
+  it("rejects multi-recipient URI construction if any recipient is invalid", () => {
+    expect(() =>
+      buildZip321Uri([
+        { address: sapling1, amount: "1.0" },
+        { address: transparent1, amount: "0.5", memo: "Invalid transparent memo" },
+      ]),
+    ).toThrow(/Memos are not supported for transparent addresses/i);
+
+    expect(() =>
+      buildZip321Uri([
+        { address: sapling1, amount: "-5" },
+        { address: sapling2, amount: "1.0" },
+      ]),
+    ).toThrow(/Recipient 1: Invalid amount/i);
+  });
+});

--- a/src/lib/zip321.ts
+++ b/src/lib/zip321.ts
@@ -1,0 +1,352 @@
+/**
+ * ZIP 321: Payment Request URIs
+ * Spec: https://zips.z.cash/zip-0321
+ *
+ * Enforces:
+ * - Positive decimal amounts with at most 8 decimal places (zatoshi precision).
+ * - Proper decimal formatting without scientific notation (e.g. 1e-8 -> "0.00000001").
+ * - Rejection of negative amounts, zero amounts, and amounts exceeding max supply (21,000,000 ZEC).
+ * - Base64url memo encoding without '=' padding.
+ * - Strict 512-byte UTF-8 memo length limit.
+ * - Rejection of memos attached to transparent addresses (t1, t3, tm).
+ * - Single-recipient and multi-recipient (indexed) payment request generation and parsing.
+ */
+
+export const MAX_ZEC_SUPPLY = 21_000_000;
+export const MAX_MEMO_BYTES = 512;
+export const ZATOSHI_DECIMALS = 8;
+
+export interface Zip321PaymentItem {
+  address: string;
+  amount?: number | string;
+  memo?: string;
+  label?: string;
+  message?: string;
+}
+
+/**
+ * Checks if a Zcash address is a transparent address (t1, t3, tm).
+ */
+export function isTransparentAddress(address: string): boolean {
+  if (!address) return false;
+  const trimmed = address.trim();
+  return (
+    trimmed.startsWith("t1") ||
+    trimmed.startsWith("t3") ||
+    trimmed.startsWith("tm")
+  );
+}
+
+/**
+ * Checks if a Zcash address supports shielded memos (Sapling, Unified, Sprout).
+ */
+export function isShieldedAddress(address: string): boolean {
+  if (!address) return false;
+  const trimmed = address.trim();
+  return (
+    trimmed.startsWith("zs") ||
+    trimmed.startsWith("u1") ||
+    trimmed.startsWith("utest1") ||
+    trimmed.startsWith("ztestsapling") ||
+    trimmed.startsWith("zc")
+  );
+}
+
+/**
+ * Formats a ZEC amount into a valid ZIP-321 decimal string.
+ * Ensures no scientific notation (1e-8 -> 0.00000001), validates positive value,
+ * max supply bound, and at most 8 decimal places.
+ */
+export function formatZecAmount(amount: number | string): string {
+  if (amount === undefined || amount === null || amount === "") {
+    throw new Error("Amount is required");
+  }
+
+  let str: string;
+  if (typeof amount === "number") {
+    if (isNaN(amount) || !isFinite(amount)) {
+      throw new Error("Invalid amount: must be a finite number");
+    }
+    if (amount <= 0) {
+      throw new Error("Invalid amount: must be greater than zero");
+    }
+    // Handle JavaScript floating-point scientific notation (e.g. 1e-8)
+    // Convert to fixed string with 8 decimals, then trim trailing zeroes
+    str = amount.toFixed(8);
+  } else {
+    str = amount.trim();
+    if (/e/i.test(str)) {
+      const num = Number(str);
+      if (isNaN(num) || !isFinite(num) || num <= 0) {
+        throw new Error("Invalid amount: must be greater than zero");
+      }
+      str = num.toFixed(8);
+    }
+  }
+
+  // Validate decimal format: positive decimal number
+  if (!/^\d+(\.\d+)?$/.test(str)) {
+    throw new Error("Invalid amount format: must be a positive decimal number");
+  }
+
+  const parts = str.split(".");
+  let intPart = parts[0];
+  const fracPart = parts[1] || "";
+
+  if (fracPart.length > ZATOSHI_DECIMALS) {
+    throw new Error(
+      `Invalid amount: exceeds maximum ${ZATOSHI_DECIMALS} decimal places (zatoshi precision)`,
+    );
+  }
+
+  // Strip leading zeroes from integer part: "01" -> "1", "00" -> "0"
+  intPart = intPart.replace(/^0+(?=\d)/, "") || "0";
+
+  const numVal = parseFloat(`${intPart}${fracPart ? "." + fracPart : ""}`);
+  if (numVal <= 0) {
+    throw new Error("Invalid amount: must be greater than zero");
+  }
+  if (numVal > MAX_ZEC_SUPPLY) {
+    throw new Error(
+      `Invalid amount: exceeds maximum ZEC supply (${MAX_ZEC_SUPPLY})`,
+    );
+  }
+
+  // Normalize: remove redundant trailing zeroes in fractional part, but keep whole number or needed decimals
+  if (fracPart) {
+    const trimmedFrac = fracPart.replace(/0+$/, "");
+    return trimmedFrac ? `${intPart}.${trimmedFrac}` : intPart;
+  }
+
+  return intPart;
+}
+
+/**
+ * Validates and encodes a memo string into base64url format without '=' padding per ZIP 321.
+ * Throws if the memo is attached to a transparent address or exceeds 512 bytes.
+ */
+export function encodeZip321Memo(memo: string, address?: string): string {
+  if (!memo) return "";
+
+  if (address && isTransparentAddress(address)) {
+    throw new Error(
+      "Memos are not supported for transparent addresses in ZIP 321",
+    );
+  }
+
+  const bytes = new TextEncoder().encode(memo);
+  if (bytes.length > MAX_MEMO_BYTES) {
+    throw new Error(
+      `Memo exceeds ${MAX_MEMO_BYTES}-byte limit (actual: ${bytes.length} bytes)`,
+    );
+  }
+
+  // Convert Uint8Array to binary string
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+
+  // Base64url encode without padding
+  const base64 = btoa(binary);
+  return base64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Decodes a ZIP-321 base64url encoded memo back to a UTF-8 string.
+ */
+export function decodeZip321Memo(encoded: string): string {
+  if (!encoded) return "";
+
+  let b64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+  while (b64.length % 4 !== 0) {
+    b64 += "=";
+  }
+
+  const binary = atob(b64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+
+  return new TextDecoder().decode(bytes);
+}
+
+/**
+ * Validates a single ZIP-321 payment item.
+ */
+export function validateZip321Payment(payment: Zip321PaymentItem): {
+  valid: boolean;
+  error?: string;
+} {
+  if (!payment.address || !payment.address.trim()) {
+    return { valid: false, error: "Address is required" };
+  }
+
+  if (payment.amount !== undefined && payment.amount !== null && payment.amount !== "") {
+    try {
+      formatZecAmount(payment.amount);
+    } catch (err) {
+      return {
+        valid: false,
+        error: err instanceof Error ? err.message : "Invalid amount",
+      };
+    }
+  }
+
+  if (payment.memo) {
+    if (isTransparentAddress(payment.address)) {
+      return {
+        valid: false,
+        error: "Memos are not supported for transparent addresses in ZIP 321",
+      };
+    }
+
+    const bytes = new TextEncoder().encode(payment.memo);
+    if (bytes.length > MAX_MEMO_BYTES) {
+      return {
+        valid: false,
+        error: `Memo exceeds ${MAX_MEMO_BYTES}-byte limit (actual: ${bytes.length} bytes)`,
+      };
+    }
+  }
+
+  return { valid: true };
+}
+
+/**
+ * Builds a ZIP-321 compliant URI from an array of payment items.
+ * Supports single-recipient and multi-recipient requests.
+ */
+export function buildZip321Uri(payments: Zip321PaymentItem[]): string {
+  if (!payments || payments.length === 0) {
+    throw new Error("At least one payment item is required");
+  }
+
+  // Validate all payments
+  for (let i = 0; i < payments.length; i++) {
+    const validation = validateZip321Payment(payments[i]);
+    if (!validation.valid) {
+      throw new Error(`Recipient ${i + 1}: ${validation.error}`);
+    }
+  }
+
+  // If single recipient: standard allows zcash:<address>?amount=... format or query-only format
+  if (payments.length === 1) {
+    const p = payments[0];
+    const params = new URLSearchParams();
+
+    if (p.amount !== undefined && p.amount !== null && p.amount !== "") {
+      params.append("amount", formatZecAmount(p.amount));
+    }
+    if (p.label) {
+      params.append("label", p.label);
+    }
+    if (p.message) {
+      params.append("message", p.message);
+    }
+    if (p.memo) {
+      params.append("memo", encodeZip321Memo(p.memo, p.address));
+    }
+
+    const qs = params.toString();
+    return qs ? `zcash:${p.address}?${qs}` : `zcash:${p.address}`;
+  }
+
+  // Multi-recipient: index parameters (primary without suffix or with .0, subsequent with .1, .2, etc.)
+  const params = new URLSearchParams();
+
+  payments.forEach((p, i) => {
+    const idx = i === 0 ? "" : `.${i}`;
+
+    params.append(`address${idx}`, p.address);
+
+    if (p.amount !== undefined && p.amount !== null && p.amount !== "") {
+      params.append(`amount${idx}`, formatZecAmount(p.amount));
+    }
+    if (p.label) {
+      params.append(`label${idx}`, p.label);
+    }
+    if (p.message) {
+      params.append(`message${idx}`, p.message);
+    }
+    if (p.memo) {
+      params.append(`memo${idx}`, encodeZip321Memo(p.memo, p.address));
+    }
+  });
+
+  return `zcash:?${params.toString()}`;
+}
+
+/**
+ * Parses a ZIP-321 compliant URI into an array of payment items.
+ * Supports single-recipient (path address or query param) and multi-recipient (indexed) requests.
+ */
+export function parseZip321Uri(uri: string): Zip321PaymentItem[] {
+  if (!uri || !uri.startsWith("zcash:")) {
+    throw new Error("Invalid URI: must start with 'zcash:'");
+  }
+
+  const withoutScheme = uri.slice(6);
+  const [pathPart, queryPart] = withoutScheme.split("?");
+
+  const params = new URLSearchParams(queryPart || "");
+  const paymentsMap = new Map<string, Partial<Zip321PaymentItem>>();
+
+  // Path address is recipient 0 if present
+  if (pathPart) {
+    paymentsMap.set("0", { address: decodeURIComponent(pathPart) });
+  }
+
+  for (const [key, value] of params.entries()) {
+    const dotIndex = key.indexOf(".");
+    const paramName = dotIndex === -1 ? key : key.slice(0, dotIndex);
+    const indexStr = dotIndex === -1 ? "0" : key.slice(dotIndex + 1);
+
+    if (!paymentsMap.has(indexStr)) {
+      paymentsMap.set(indexStr, {});
+    }
+    const item = paymentsMap.get(indexStr)!;
+
+    if (paramName === "address") {
+      item.address = value;
+    } else if (paramName === "amount") {
+      item.amount = formatZecAmount(value);
+    } else if (paramName === "label") {
+      item.label = value;
+    } else if (paramName === "message") {
+      item.message = value;
+    } else if (paramName === "memo") {
+      item.memo = decodeZip321Memo(value);
+    }
+  }
+
+  // Sort by index numeric order (0, 1, 2...)
+  const sortedIndices = Array.from(paymentsMap.keys()).sort((a, b) => {
+    const numA = parseInt(a, 10);
+    const numB = parseInt(b, 10);
+    if (isNaN(numA)) return 1;
+    if (isNaN(numB)) return -1;
+    return numA - numB;
+  });
+
+  const result: Zip321PaymentItem[] = [];
+  for (const idx of sortedIndices) {
+    const p = paymentsMap.get(idx)!;
+    if (!p.address) {
+      throw new Error(`Recipient ${idx} is missing an address`);
+    }
+    const validation = validateZip321Payment(p as Zip321PaymentItem);
+    if (!validation.valid) {
+      throw new Error(`Recipient ${idx}: ${validation.error}`);
+    }
+    result.push(p as Zip321PaymentItem);
+  }
+
+  if (result.length === 0) {
+    throw new Error("No payment items found in URI");
+  }
+
+  return result;
+}
+


### PR DESCRIPTION
### Overview

Resolves ZecHub Bounty `cmtvvgqtu0004cvpck46u4k6m` (0.34 ZEC): *"Fix invalid ZIP-321 payment requests across ZecHub’s builder and QR widget"*.
Tag: @ZecHub/bounties cmtvvgqtu0004cvpck46u4k6m

### Key Fixes & ZIP-321 Compliance

1. **Strict Amount Validation & Formatting (`src/lib/zip321.ts`)**:
   - Enforces positive decimal amounts up to 8 decimal places (zatoshi precision).
   - Prevents scientific notation leakage (e.g. `1e-8` serializes cleanly as `0.00000001`).
   - Rejects zero amounts (`0`, `0.00000000`), negative amounts, and amounts exceeding 21,000,000 ZEC.
   - Normalizes redundant leading and trailing zeroes.

2. **Transparent Address Memo Prohibition**:
   - Transparent addresses (`t1`, `t3`, `tm`) strictly prohibit attached memos per ZIP-321 across the builder, widget, and QR code API.
   - UI warns users with contextual notifications if attempting to attach memos to transparent addresses.

3. **512-Byte UTF-8 Memo Limit & Base64url Encoding**:
   - Enforces strict 512-byte limit based on UTF-8 byte length (properly accounting for multi-byte Unicode and emoji characters).
   - Encodes memos as base64url without '=' padding per RFC 4648 / ZIP-321.

4. **Single and Multi-Recipient URI Builder & Parser**:
   - Implements `buildZip321Uri` and `parseZip321Uri` supporting single-recipient (`zcash:<address>?...`) and multi-recipient indexed queries (`address.1`, `amount.1`, `memo.1`).

5. **Widget Bug Fix**:
   - Fixed `loadWithRetry` infinite loop / incorrect assignment `(i = retries)` in `adapters/helpers/index.ts`.

6. **Comprehensive Regression Test Suite (`src/lib/__tests__/zip321.test.ts`)**:
   - 35+ test assertions covering amount boundaries, precision overflow, zero/negative rejection, transparent address memo rejection, 512-byte UTF-8 boundary checks, Unicode roundtrips, and single/multi-recipient parsing.