### PR TITLE
fix(developers): use command substitution $(pwd) in Zebra export PATH

### DIFF
--- a/src/app/[locale]/developers/quick-start/QuickStartClient.tsx
+++ b/src/app/[locale]/developers/quick-start/QuickStartClient.tsx
@@ -396,7 +396,7 @@ const ZebradTab = () => {
               {qs?.fromSource ?? "From Source"}
             </SubLabel>
             <CodeBlock
-              code={`git clone https://github.com/ZcashFoundation/zebra.git\ncd zebra\ngit checkout v6.3.0\ncargo build --release --bin zebrad\nexport PATH="$PATH:(pwd)/target/release"`}
+              code={`git clone https://github.com/ZcashFoundation/zebra.git\ncd zebra\ngit checkout v6.3.0\ncargo build --release --bin zebrad\nexport PATH="$PATH:$(pwd)/target/release"`}
             />
             <SubLabel className="mt-[14px]">
               {qs?.alternatively ?? "Alternatively"}
@@ -419,7 +419,7 @@ const ZebradTab = () => {
               {qs?.manualDownload ?? "Manual Download"}
             </SubLabel>
             <CodeBlock
-              code={`git clone https://github.com/ZcashFoundation/zebra.git\ncd zebra\ngit checkout v6.3.0\ncargo build --release --bin zebrad\nexport PATH="$PATH:(pwd)/target/release"`}
+              code={`git clone https://github.com/ZcashFoundation/zebra.git\ncd zebra\ngit checkout v6.3.0\ncargo build --release --bin zebrad\nexport PATH="$PATH:$(pwd)/target/release"`}
             />
             <SubLabel className="mt-[14px]">
               {qs?.alternatively ?? "Alternatively"}
@@ -444,7 +444,7 @@ const ZebradTab = () => {
               {qs?.fromSource ?? "From Source"}
             </SubLabel>
             <CodeBlock
-              code={`git clone https://github.com/ZcashFoundation/zebra.git\ncd zebra\ngit checkout v6.3.0\ncargo build --release --bin zebrad\nexport PATH="$PATH:(pwd)/target/release"`}
+              code={`git clone https://github.com/ZcashFoundation/zebra.git\ncd zebra\ngit checkout v6.3.0\ncargo build --release --bin zebrad\nexport PATH="$PATH:$(pwd)/target/release"`}
             />
             <SubLabel className="mt-[14px]">
               {qs?.alternatively ?? "Alternatively"}


### PR DESCRIPTION
### Summary

Resolves ZecHub Bounty `cmtre5cmy0047cvaczwi16f11` (0.05 ZEC): *"Shell command on the Developer Quick Start page sets the wrong PATH"*.
Tag: @ZecHub/bounties cmtre5cmy0047cvaczwi16f11

### Changes Made

- In `src/app/[locale]/developers/quick-start/QuickStartClient.tsx`, changed `export PATH="$PATH:(pwd)/target/release"` to `export PATH="$PATH:$(pwd)/target/release"` across all three tabs (Linux, macOS, Windows).
- Inside quotes `(pwd)` was the literal four-character string instead of command substitution `$(pwd)`, causing `zebrad` not to be found after build.