### PR TITLE
fix(a11y): replace blanket outline removal with accessible focus-visible indicator

### DIFF
--- a/src/app/[locale]/globals.css
+++ b/src/app/[locale]/globals.css
@@ -100,12 +100,13 @@
   --radius-sm: calc(var(--radius) - 4px);
 }
 
-*:focus {
-  outline: none !important;
+*:focus:not(:focus-visible) {
+  outline: none;
 }
 
 *:focus-visible {
-  outline: none !important;
+  outline: 2px solid #f4b728;
+  outline-offset: 2px;
 }
 
 .btn-brand {


### PR DESCRIPTION
### Summary

Resolves ZecHub Bounty `cmtrhisq1004rcvac9p68w308` (0.10 ZEC): *"Nothing on the wiki shows a focus outline, so you cannot see where you are when tabbing"*.
Tag: @ZecHub/bounties cmtrhisq1004rcvac9p68w308

### Accessibility Problem & Solution

- **Issue**: `globals.css` previously stripped outlines across every element on the entire site using `*:focus` and `*:focus-visible` with `outline: none !important`. Keyboard users tabbing through interactive controls or visualizers could not see focus position (WCAG 2.4.7 / Level AA violation).
- **Fix**:
  - Replaced the blanket `!important` outline removal with an accessible keyboard focus indicator: `*:focus-visible { outline: 2px solid #f4b728; outline-offset: 2px; }`.
  - Maintained clean pointer behavior on mouse clicks via `*:focus:not(:focus-visible) { outline: none; }`.