### PR TITLE
fix(tools): detect ZIP-320 TEX addresses

### DIFF
--- a/src/app/[locale]/tools/helper/__tests__/index.test.ts
+++ b/src/app/[locale]/tools/helper/__tests__/index.test.ts
@@ -1,0 +1,49 @@
+import { detectZcashNetwork } from "../index";
+
+describe("detectZcashNetwork", () => {
+  it("detects mainnet ZIP-320 TEX addresses", () => {
+    expect(detectZcashNetwork("tex1s2rt77ggcyr4rn0kfktll9m9wsxlv4t6uhpldk")).toBe(
+      "mainnet",
+    );
+  });
+
+  it("detects testnet ZIP-320 TEX addresses", () => {
+    expect(
+      detectZcashNetwork("textest1s2rt77ggcyr4rn0kfktll9m9wsxlv4t6uhpldk"),
+    ).toBe("testnet");
+  });
+
+  it("still detects existing testnet address prefixes", () => {
+    expect(detectZcashNetwork("tm9iMLAuYMzJ6jtFLcA7rzUmfreCV2z6vys")).toBe(
+      "testnet",
+    );
+    expect(
+      detectZcashNetwork("utest1p0906hsww2yq77l249qj4swj72n9q3t0a6k9d7a2y29"),
+    ).toBe("testnet");
+    expect(
+      detectZcashNetwork(
+        "ztestsapling1knwqq0y5x0kf0jjyw6jswpzw7xjq0dt3wtcvguxr7v7t7cnv2cxnprqymvyjr8t7t9x0ny8t6ct",
+      ),
+    ).toBe("testnet");
+  });
+
+  it("still detects existing mainnet address prefixes", () => {
+    expect(detectZcashNetwork("t1VpMigELggqi6TBghQNehqspAcBBDYvRQC")).toBe(
+      "mainnet",
+    );
+    expect(
+      detectZcashNetwork(
+        "zs1znewaqucqpc372x6ajmfnmkmxsafnc3fuxmg6g5kq3mkvkv8ufx9hgx9vgcrqncqm3umz56a7pd",
+      ),
+    ).toBe("mainnet");
+    expect(
+      detectZcashNetwork("u1p0906hsww2yq77l249qj4swj72n9q3t0a6k9d7a2y29"),
+    ).toBe("mainnet");
+  });
+
+  it("returns unknown for unrecognized or empty input", () => {
+    expect(detectZcashNetwork("")).toBe("unknown");
+    expect(detectZcashNetwork("not-a-zcash-address")).toBe("unknown");
+    expect(detectZcashNetwork("bc1qxyz")).toBe("unknown");
+  });
+});

--- a/src/app/[locale]/tools/helper/index.ts
+++ b/src/app/[locale]/tools/helper/index.ts
@@ -7,7 +7,8 @@ export function detectZcashNetwork(addr: string): ZcashNetwork {
   if (
     addr.startsWith("tm") ||
     addr.startsWith("utest1") ||
-    addr.startsWith("ztestsapling")
+    addr.startsWith("ztestsapling") ||
+    addr.startsWith("textest1")
   ) {
     return "testnet";
   }
@@ -16,7 +17,8 @@ export function detectZcashNetwork(addr: string): ZcashNetwork {
   if (
     addr.startsWith("t1") ||
     addr.startsWith("zs1") ||
-    addr.startsWith("u1")
+    addr.startsWith("u1") ||
+    addr.startsWith("tex1")
   ) {
     return "mainnet";
   }


### PR DESCRIPTION
## Problem
TEX addresses were falling through `detectZcashNetwork` and could be displayed as the wrong network.

## Fix
Recognize `tex1` as mainnet and `textest1` as testnet.

## Tests
New detection coverage plus existing-prefix regression checks; full Jest suite 135/135 passed; ESLint clean.

TypeScript check has pre-existing unrelated static-asset/module errors; no errors reference these changed files.

## Scope note
This intentionally does not touch any files or work claimed by open PR #810.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sXn8ePeRtesmkUXhEdL7s