### PR TITLE
fix(payment-widget): generate embed QR codes client-side

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "eslint-config-prettier": "^9.1.0",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "jsqr": "^1.4.0",
     "tailwindcss-animate": "^1.0.7",
     "tsx": "^4.19.3"
   },

--- a/public/zcash-payment-request-widget.embed.v2.js
+++ b/public/zcash-payment-request-widget.embed.v2.js
@@ -2,6 +2,675 @@
 
 /*! zcash-payment-request-widget.embed.v2.js | (c) PayWithZcash Widget | Dual-mode: auto + programmatic */
 (async function () {
+
+  // ---------- Vendored QR code generator (100% client-side; no network call) ----------
+  // This file is a dependency-free static script loaded via a single <script src>
+  // tag on third-party sites (no bundler in the loop), so QR generation must not
+  // depend on a server request (payment privacy) or a runtime CDN import. The code
+  // below is copied, unmodified in logic, from qrcode.react v3.2.0
+  // (https://www.npmjs.com/package/qrcode.react), already a dependency of this
+  // project (see package.json), which itself vendors Project Nayuki's QR Code
+  // generator library. Original license notices are preserved below.
+
+  /**
+   * @license QR Code generator library (TypeScript)
+   * Copyright (c) Project Nayuki.
+   * SPDX-License-Identifier: MIT
+   */
+  var qrcodegen;
+  ((qrcodegen2) => {
+    const _QrCode = class {
+      constructor(version, errorCorrectionLevel, dataCodewords, msk) {
+        this.version = version;
+        this.errorCorrectionLevel = errorCorrectionLevel;
+        this.modules = [];
+        this.isFunction = [];
+        if (version < _QrCode.MIN_VERSION || version > _QrCode.MAX_VERSION)
+          throw new RangeError("Version value out of range");
+        if (msk < -1 || msk > 7)
+          throw new RangeError("Mask value out of range");
+        this.size = version * 4 + 17;
+        let row = [];
+        for (let i = 0; i < this.size; i++)
+          row.push(false);
+        for (let i = 0; i < this.size; i++) {
+          this.modules.push(row.slice());
+          this.isFunction.push(row.slice());
+        }
+        this.drawFunctionPatterns();
+        const allCodewords = this.addEccAndInterleave(dataCodewords);
+        this.drawCodewords(allCodewords);
+        if (msk == -1) {
+          let minPenalty = 1e9;
+          for (let i = 0; i < 8; i++) {
+            this.applyMask(i);
+            this.drawFormatBits(i);
+            const penalty = this.getPenaltyScore();
+            if (penalty < minPenalty) {
+              msk = i;
+              minPenalty = penalty;
+            }
+            this.applyMask(i);
+          }
+        }
+        assert(0 <= msk && msk <= 7);
+        this.mask = msk;
+        this.applyMask(msk);
+        this.drawFormatBits(msk);
+        this.isFunction = [];
+      }
+      static encodeText(text, ecl) {
+        const segs = qrcodegen2.QrSegment.makeSegments(text);
+        return _QrCode.encodeSegments(segs, ecl);
+      }
+      static encodeBinary(data, ecl) {
+        const seg = qrcodegen2.QrSegment.makeBytes(data);
+        return _QrCode.encodeSegments([seg], ecl);
+      }
+      static encodeSegments(segs, ecl, minVersion = 1, maxVersion = 40, mask = -1, boostEcl = true) {
+        if (!(_QrCode.MIN_VERSION <= minVersion && minVersion <= maxVersion && maxVersion <= _QrCode.MAX_VERSION) || mask < -1 || mask > 7)
+          throw new RangeError("Invalid value");
+        let version;
+        let dataUsedBits;
+        for (version = minVersion; ; version++) {
+          const dataCapacityBits2 = _QrCode.getNumDataCodewords(version, ecl) * 8;
+          const usedBits = QrSegment.getTotalBits(segs, version);
+          if (usedBits <= dataCapacityBits2) {
+            dataUsedBits = usedBits;
+            break;
+          }
+          if (version >= maxVersion)
+            throw new RangeError("Data too long");
+        }
+        for (const newEcl of [_QrCode.Ecc.MEDIUM, _QrCode.Ecc.QUARTILE, _QrCode.Ecc.HIGH]) {
+          if (boostEcl && dataUsedBits <= _QrCode.getNumDataCodewords(version, newEcl) * 8)
+            ecl = newEcl;
+        }
+        let bb = [];
+        for (const seg of segs) {
+          appendBits(seg.mode.modeBits, 4, bb);
+          appendBits(seg.numChars, seg.mode.numCharCountBits(version), bb);
+          for (const b of seg.getData())
+            bb.push(b);
+        }
+        assert(bb.length == dataUsedBits);
+        const dataCapacityBits = _QrCode.getNumDataCodewords(version, ecl) * 8;
+        assert(bb.length <= dataCapacityBits);
+        appendBits(0, Math.min(4, dataCapacityBits - bb.length), bb);
+        appendBits(0, (8 - bb.length % 8) % 8, bb);
+        assert(bb.length % 8 == 0);
+        for (let padByte = 236; bb.length < dataCapacityBits; padByte ^= 236 ^ 17)
+          appendBits(padByte, 8, bb);
+        let dataCodewords = [];
+        while (dataCodewords.length * 8 < bb.length)
+          dataCodewords.push(0);
+        bb.forEach((b, i) => dataCodewords[i >>> 3] |= b << 7 - (i & 7));
+        return new _QrCode(version, ecl, dataCodewords, mask);
+      }
+      getModule(x, y) {
+        return 0 <= x && x < this.size && 0 <= y && y < this.size && this.modules[y][x];
+      }
+      getModules() {
+        return this.modules;
+      }
+      drawFunctionPatterns() {
+        for (let i = 0; i < this.size; i++) {
+          this.setFunctionModule(6, i, i % 2 == 0);
+          this.setFunctionModule(i, 6, i % 2 == 0);
+        }
+        this.drawFinderPattern(3, 3);
+        this.drawFinderPattern(this.size - 4, 3);
+        this.drawFinderPattern(3, this.size - 4);
+        const alignPatPos = this.getAlignmentPatternPositions();
+        const numAlign = alignPatPos.length;
+        for (let i = 0; i < numAlign; i++) {
+          for (let j = 0; j < numAlign; j++) {
+            if (!(i == 0 && j == 0 || i == 0 && j == numAlign - 1 || i == numAlign - 1 && j == 0))
+              this.drawAlignmentPattern(alignPatPos[i], alignPatPos[j]);
+          }
+        }
+        this.drawFormatBits(0);
+        this.drawVersion();
+      }
+      drawFormatBits(mask) {
+        const data = this.errorCorrectionLevel.formatBits << 3 | mask;
+        let rem = data;
+        for (let i = 0; i < 10; i++)
+          rem = rem << 1 ^ (rem >>> 9) * 1335;
+        const bits = (data << 10 | rem) ^ 21522;
+        assert(bits >>> 15 == 0);
+        for (let i = 0; i <= 5; i++)
+          this.setFunctionModule(8, i, getBit(bits, i));
+        this.setFunctionModule(8, 7, getBit(bits, 6));
+        this.setFunctionModule(8, 8, getBit(bits, 7));
+        this.setFunctionModule(7, 8, getBit(bits, 8));
+        for (let i = 9; i < 15; i++)
+          this.setFunctionModule(14 - i, 8, getBit(bits, i));
+        for (let i = 0; i < 8; i++)
+          this.setFunctionModule(this.size - 1 - i, 8, getBit(bits, i));
+        for (let i = 8; i < 15; i++)
+          this.setFunctionModule(8, this.size - 15 + i, getBit(bits, i));
+        this.setFunctionModule(8, this.size - 8, true);
+      }
+      drawVersion() {
+        if (this.version < 7)
+          return;
+        let rem = this.version;
+        for (let i = 0; i < 12; i++)
+          rem = rem << 1 ^ (rem >>> 11) * 7973;
+        const bits = this.version << 12 | rem;
+        assert(bits >>> 18 == 0);
+        for (let i = 0; i < 18; i++) {
+          const color = getBit(bits, i);
+          const a = this.size - 11 + i % 3;
+          const b = Math.floor(i / 3);
+          this.setFunctionModule(a, b, color);
+          this.setFunctionModule(b, a, color);
+        }
+      }
+      drawFinderPattern(x, y) {
+        for (let dy = -4; dy <= 4; dy++) {
+          for (let dx = -4; dx <= 4; dx++) {
+            const dist = Math.max(Math.abs(dx), Math.abs(dy));
+            const xx = x + dx;
+            const yy = y + dy;
+            if (0 <= xx && xx < this.size && 0 <= yy && yy < this.size)
+              this.setFunctionModule(xx, yy, dist != 2 && dist != 4);
+          }
+        }
+      }
+      drawAlignmentPattern(x, y) {
+        for (let dy = -2; dy <= 2; dy++) {
+          for (let dx = -2; dx <= 2; dx++)
+            this.setFunctionModule(x + dx, y + dy, Math.max(Math.abs(dx), Math.abs(dy)) != 1);
+        }
+      }
+      setFunctionModule(x, y, isDark) {
+        this.modules[y][x] = isDark;
+        this.isFunction[y][x] = true;
+      }
+      addEccAndInterleave(data) {
+        const ver = this.version;
+        const ecl = this.errorCorrectionLevel;
+        if (data.length != _QrCode.getNumDataCodewords(ver, ecl))
+          throw new RangeError("Invalid argument");
+        const numBlocks = _QrCode.NUM_ERROR_CORRECTION_BLOCKS[ecl.ordinal][ver];
+        const blockEccLen = _QrCode.ECC_CODEWORDS_PER_BLOCK[ecl.ordinal][ver];
+        const rawCodewords = Math.floor(_QrCode.getNumRawDataModules(ver) / 8);
+        const numShortBlocks = numBlocks - rawCodewords % numBlocks;
+        const shortBlockLen = Math.floor(rawCodewords / numBlocks);
+        let blocks = [];
+        const rsDiv = _QrCode.reedSolomonComputeDivisor(blockEccLen);
+        for (let i = 0, k = 0; i < numBlocks; i++) {
+          let dat = data.slice(k, k + shortBlockLen - blockEccLen + (i < numShortBlocks ? 0 : 1));
+          k += dat.length;
+          const ecc = _QrCode.reedSolomonComputeRemainder(dat, rsDiv);
+          if (i < numShortBlocks)
+            dat.push(0);
+          blocks.push(dat.concat(ecc));
+        }
+        let result = [];
+        for (let i = 0; i < blocks[0].length; i++) {
+          blocks.forEach((block, j) => {
+            if (i != shortBlockLen - blockEccLen || j >= numShortBlocks)
+              result.push(block[i]);
+          });
+        }
+        assert(result.length == rawCodewords);
+        return result;
+      }
+      drawCodewords(data) {
+        if (data.length != Math.floor(_QrCode.getNumRawDataModules(this.version) / 8))
+          throw new RangeError("Invalid argument");
+        let i = 0;
+        for (let right = this.size - 1; right >= 1; right -= 2) {
+          if (right == 6)
+            right = 5;
+          for (let vert = 0; vert < this.size; vert++) {
+            for (let j = 0; j < 2; j++) {
+              const x = right - j;
+              const upward = (right + 1 & 2) == 0;
+              const y = upward ? this.size - 1 - vert : vert;
+              if (!this.isFunction[y][x] && i < data.length * 8) {
+                this.modules[y][x] = getBit(data[i >>> 3], 7 - (i & 7));
+                i++;
+              }
+            }
+          }
+        }
+        assert(i == data.length * 8);
+      }
+      applyMask(mask) {
+        if (mask < 0 || mask > 7)
+          throw new RangeError("Mask value out of range");
+        for (let y = 0; y < this.size; y++) {
+          for (let x = 0; x < this.size; x++) {
+            let invert;
+            switch (mask) {
+              case 0:
+                invert = (x + y) % 2 == 0;
+                break;
+              case 1:
+                invert = y % 2 == 0;
+                break;
+              case 2:
+                invert = x % 3 == 0;
+                break;
+              case 3:
+                invert = (x + y) % 3 == 0;
+                break;
+              case 4:
+                invert = (Math.floor(x / 3) + Math.floor(y / 2)) % 2 == 0;
+                break;
+              case 5:
+                invert = x * y % 2 + x * y % 3 == 0;
+                break;
+              case 6:
+                invert = (x * y % 2 + x * y % 3) % 2 == 0;
+                break;
+              case 7:
+                invert = ((x + y) % 2 + x * y % 3) % 2 == 0;
+                break;
+              default:
+                throw new Error("Unreachable");
+            }
+            if (!this.isFunction[y][x] && invert)
+              this.modules[y][x] = !this.modules[y][x];
+          }
+        }
+      }
+      getPenaltyScore() {
+        let result = 0;
+        for (let y = 0; y < this.size; y++) {
+          let runColor = false;
+          let runX = 0;
+          let runHistory = [0, 0, 0, 0, 0, 0, 0];
+          for (let x = 0; x < this.size; x++) {
+            if (this.modules[y][x] == runColor) {
+              runX++;
+              if (runX == 5)
+                result += _QrCode.PENALTY_N1;
+              else if (runX > 5)
+                result++;
+            } else {
+              this.finderPenaltyAddHistory(runX, runHistory);
+              if (!runColor)
+                result += this.finderPenaltyCountPatterns(runHistory) * _QrCode.PENALTY_N3;
+              runColor = this.modules[y][x];
+              runX = 1;
+            }
+          }
+          result += this.finderPenaltyTerminateAndCount(runColor, runX, runHistory) * _QrCode.PENALTY_N3;
+        }
+        for (let x = 0; x < this.size; x++) {
+          let runColor = false;
+          let runY = 0;
+          let runHistory = [0, 0, 0, 0, 0, 0, 0];
+          for (let y = 0; y < this.size; y++) {
+            if (this.modules[y][x] == runColor) {
+              runY++;
+              if (runY == 5)
+                result += _QrCode.PENALTY_N1;
+              else if (runY > 5)
+                result++;
+            } else {
+              this.finderPenaltyAddHistory(runY, runHistory);
+              if (!runColor)
+                result += this.finderPenaltyCountPatterns(runHistory) * _QrCode.PENALTY_N3;
+              runColor = this.modules[y][x];
+              runY = 1;
+            }
+          }
+          result += this.finderPenaltyTerminateAndCount(runColor, runY, runHistory) * _QrCode.PENALTY_N3;
+        }
+        for (let y = 0; y < this.size - 1; y++) {
+          for (let x = 0; x < this.size - 1; x++) {
+            const color = this.modules[y][x];
+            if (color == this.modules[y][x + 1] && color == this.modules[y + 1][x] && color == this.modules[y + 1][x + 1])
+              result += _QrCode.PENALTY_N2;
+          }
+        }
+        let dark = 0;
+        for (const row of this.modules)
+          dark = row.reduce((sum, color) => sum + (color ? 1 : 0), dark);
+        const total = this.size * this.size;
+        const k = Math.ceil(Math.abs(dark * 20 - total * 10) / total) - 1;
+        assert(0 <= k && k <= 9);
+        result += k * _QrCode.PENALTY_N4;
+        assert(0 <= result && result <= 2568888);
+        return result;
+      }
+      getAlignmentPatternPositions() {
+        if (this.version == 1)
+          return [];
+        else {
+          const numAlign = Math.floor(this.version / 7) + 2;
+          const step = this.version == 32 ? 26 : Math.ceil((this.version * 4 + 4) / (numAlign * 2 - 2)) * 2;
+          let result = [6];
+          for (let pos = this.size - 7; result.length < numAlign; pos -= step)
+            result.splice(1, 0, pos);
+          return result;
+        }
+      }
+      static getNumRawDataModules(ver) {
+        if (ver < _QrCode.MIN_VERSION || ver > _QrCode.MAX_VERSION)
+          throw new RangeError("Version number out of range");
+        let result = (16 * ver + 128) * ver + 64;
+        if (ver >= 2) {
+          const numAlign = Math.floor(ver / 7) + 2;
+          result -= (25 * numAlign - 10) * numAlign - 55;
+          if (ver >= 7)
+            result -= 36;
+        }
+        assert(208 <= result && result <= 29648);
+        return result;
+      }
+      static getNumDataCodewords(ver, ecl) {
+        return Math.floor(_QrCode.getNumRawDataModules(ver) / 8) - _QrCode.ECC_CODEWORDS_PER_BLOCK[ecl.ordinal][ver] * _QrCode.NUM_ERROR_CORRECTION_BLOCKS[ecl.ordinal][ver];
+      }
+      static reedSolomonComputeDivisor(degree) {
+        if (degree < 1 || degree > 255)
+          throw new RangeError("Degree out of range");
+        let result = [];
+        for (let i = 0; i < degree - 1; i++)
+          result.push(0);
+        result.push(1);
+        let root = 1;
+        for (let i = 0; i < degree; i++) {
+          for (let j = 0; j < result.length; j++) {
+            result[j] = _QrCode.reedSolomonMultiply(result[j], root);
+            if (j + 1 < result.length)
+              result[j] ^= result[j + 1];
+          }
+          root = _QrCode.reedSolomonMultiply(root, 2);
+        }
+        return result;
+      }
+      static reedSolomonComputeRemainder(data, divisor) {
+        let result = divisor.map((_) => 0);
+        for (const b of data) {
+          const factor = b ^ result.shift();
+          result.push(0);
+          divisor.forEach((coef, i) => result[i] ^= _QrCode.reedSolomonMultiply(coef, factor));
+        }
+        return result;
+      }
+      static reedSolomonMultiply(x, y) {
+        if (x >>> 8 != 0 || y >>> 8 != 0)
+          throw new RangeError("Byte out of range");
+        let z = 0;
+        for (let i = 7; i >= 0; i--) {
+          z = z << 1 ^ (z >>> 7) * 285;
+          z ^= (y >>> i & 1) * x;
+        }
+        assert(z >>> 8 == 0);
+        return z;
+      }
+      finderPenaltyCountPatterns(runHistory) {
+        const n = runHistory[1];
+        assert(n <= this.size * 3);
+        const core = n > 0 && runHistory[2] == n && runHistory[3] == n * 3 && runHistory[4] == n && runHistory[5] == n;
+        return (core && runHistory[0] >= n * 4 && runHistory[6] >= n ? 1 : 0) + (core && runHistory[6] >= n * 4 && runHistory[0] >= n ? 1 : 0);
+      }
+      finderPenaltyTerminateAndCount(currentRunColor, currentRunLength, runHistory) {
+        if (currentRunColor) {
+          this.finderPenaltyAddHistory(currentRunLength, runHistory);
+          currentRunLength = 0;
+        }
+        currentRunLength += this.size;
+        this.finderPenaltyAddHistory(currentRunLength, runHistory);
+        return this.finderPenaltyCountPatterns(runHistory);
+      }
+      finderPenaltyAddHistory(currentRunLength, runHistory) {
+        if (runHistory[0] == 0)
+          currentRunLength += this.size;
+        runHistory.pop();
+        runHistory.unshift(currentRunLength);
+      }
+    };
+    let QrCode = _QrCode;
+    QrCode.MIN_VERSION = 1;
+    QrCode.MAX_VERSION = 40;
+    QrCode.PENALTY_N1 = 3;
+    QrCode.PENALTY_N2 = 3;
+    QrCode.PENALTY_N3 = 40;
+    QrCode.PENALTY_N4 = 10;
+    QrCode.ECC_CODEWORDS_PER_BLOCK = [
+      [-1, 7, 10, 15, 20, 26, 18, 20, 24, 30, 18, 20, 24, 26, 30, 22, 24, 28, 30, 28, 28, 28, 28, 30, 30, 26, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+      [-1, 10, 16, 26, 18, 24, 16, 18, 22, 22, 26, 30, 22, 22, 24, 24, 28, 28, 26, 26, 26, 26, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28, 28],
+      [-1, 13, 22, 18, 26, 18, 24, 18, 22, 20, 24, 28, 26, 24, 20, 30, 24, 28, 28, 26, 30, 28, 30, 30, 30, 30, 28, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30],
+      [-1, 17, 28, 22, 16, 22, 28, 26, 26, 24, 28, 24, 28, 22, 24, 24, 30, 28, 28, 26, 28, 30, 24, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30]
+    ];
+    QrCode.NUM_ERROR_CORRECTION_BLOCKS = [
+      [-1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 4, 4, 4, 4, 4, 6, 6, 6, 6, 7, 8, 8, 9, 9, 10, 12, 12, 12, 13, 14, 15, 16, 17, 18, 19, 19, 20, 21, 22, 24, 25],
+      [-1, 1, 1, 1, 2, 2, 4, 4, 4, 5, 5, 5, 8, 9, 9, 10, 10, 11, 13, 14, 16, 17, 17, 18, 20, 21, 23, 25, 26, 28, 29, 31, 33, 35, 37, 38, 40, 43, 45, 47, 49],
+      [-1, 1, 1, 2, 2, 4, 4, 6, 6, 8, 8, 8, 10, 12, 16, 12, 17, 16, 18, 21, 20, 23, 23, 25, 27, 29, 34, 34, 35, 38, 40, 43, 45, 48, 51, 53, 56, 59, 62, 65, 68],
+      [-1, 1, 1, 2, 4, 4, 4, 5, 6, 8, 8, 11, 11, 16, 16, 18, 16, 19, 21, 25, 25, 25, 34, 30, 32, 35, 37, 40, 42, 45, 48, 51, 54, 57, 60, 63, 66, 70, 74, 77, 81]
+    ];
+    qrcodegen2.QrCode = QrCode;
+    function appendBits(val, len, bb) {
+      if (len < 0 || len > 31 || val >>> len != 0)
+        throw new RangeError("Value out of range");
+      for (let i = len - 1; i >= 0; i--)
+        bb.push(val >>> i & 1);
+    }
+    function getBit(x, i) {
+      return (x >>> i & 1) != 0;
+    }
+    function assert(cond) {
+      if (!cond)
+        throw new Error("Assertion error");
+    }
+    const _QrSegment = class {
+      constructor(mode, numChars, bitData) {
+        this.mode = mode;
+        this.numChars = numChars;
+        this.bitData = bitData;
+        if (numChars < 0)
+          throw new RangeError("Invalid argument");
+        this.bitData = bitData.slice();
+      }
+      static makeBytes(data) {
+        let bb = [];
+        for (const b of data)
+          appendBits(b, 8, bb);
+        return new _QrSegment(_QrSegment.Mode.BYTE, data.length, bb);
+      }
+      static makeNumeric(digits) {
+        if (!_QrSegment.isNumeric(digits))
+          throw new RangeError("String contains non-numeric characters");
+        let bb = [];
+        for (let i = 0; i < digits.length; ) {
+          const n = Math.min(digits.length - i, 3);
+          appendBits(parseInt(digits.substr(i, n), 10), n * 3 + 1, bb);
+          i += n;
+        }
+        return new _QrSegment(_QrSegment.Mode.NUMERIC, digits.length, bb);
+      }
+      static makeAlphanumeric(text) {
+        if (!_QrSegment.isAlphanumeric(text))
+          throw new RangeError("String contains unencodable characters in alphanumeric mode");
+        let bb = [];
+        let i;
+        for (i = 0; i + 2 <= text.length; i += 2) {
+          let temp = _QrSegment.ALPHANUMERIC_CHARSET.indexOf(text.charAt(i)) * 45;
+          temp += _QrSegment.ALPHANUMERIC_CHARSET.indexOf(text.charAt(i + 1));
+          appendBits(temp, 11, bb);
+        }
+        if (i < text.length)
+          appendBits(_QrSegment.ALPHANUMERIC_CHARSET.indexOf(text.charAt(i)), 6, bb);
+        return new _QrSegment(_QrSegment.Mode.ALPHANUMERIC, text.length, bb);
+      }
+      static makeSegments(text) {
+        if (text == "")
+          return [];
+        else if (_QrSegment.isNumeric(text))
+          return [_QrSegment.makeNumeric(text)];
+        else if (_QrSegment.isAlphanumeric(text))
+          return [_QrSegment.makeAlphanumeric(text)];
+        else
+          return [_QrSegment.makeBytes(_QrSegment.toUtf8ByteArray(text))];
+      }
+      static makeEci(assignVal) {
+        let bb = [];
+        if (assignVal < 0)
+          throw new RangeError("ECI assignment value out of range");
+        else if (assignVal < 1 << 7)
+          appendBits(assignVal, 8, bb);
+        else if (assignVal < 1 << 14) {
+          appendBits(2, 2, bb);
+          appendBits(assignVal, 14, bb);
+        } else if (assignVal < 1e6) {
+          appendBits(6, 3, bb);
+          appendBits(assignVal, 21, bb);
+        } else
+          throw new RangeError("ECI assignment value out of range");
+        return new _QrSegment(_QrSegment.Mode.ECI, 0, bb);
+      }
+      static isNumeric(text) {
+        return _QrSegment.NUMERIC_REGEX.test(text);
+      }
+      static isAlphanumeric(text) {
+        return _QrSegment.ALPHANUMERIC_REGEX.test(text);
+      }
+      getData() {
+        return this.bitData.slice();
+      }
+      static getTotalBits(segs, version) {
+        let result = 0;
+        for (const seg of segs) {
+          const ccbits = seg.mode.numCharCountBits(version);
+          if (seg.numChars >= 1 << ccbits)
+            return Infinity;
+          result += 4 + ccbits + seg.bitData.length;
+        }
+        return result;
+      }
+      static toUtf8ByteArray(str) {
+        str = encodeURI(str);
+        let result = [];
+        for (let i = 0; i < str.length; i++) {
+          if (str.charAt(i) != "%")
+            result.push(str.charCodeAt(i));
+          else {
+            result.push(parseInt(str.substr(i + 1, 2), 16));
+            i += 2;
+          }
+        }
+        return result;
+      }
+    };
+    let QrSegment = _QrSegment;
+    QrSegment.NUMERIC_REGEX = /^[0-9]*$/;
+    QrSegment.ALPHANUMERIC_REGEX = /^[A-Z0-9 $%*+.\/:-]*$/;
+    QrSegment.ALPHANUMERIC_CHARSET = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ $%*+-./:";
+    qrcodegen2.QrSegment = QrSegment;
+  })(qrcodegen || (qrcodegen = {}));
+  ((qrcodegen2) => {
+    let QrCode;
+    ((QrCode2) => {
+      const _Ecc = class {
+        constructor(ordinal, formatBits) {
+          this.ordinal = ordinal;
+          this.formatBits = formatBits;
+        }
+      };
+      let Ecc = _Ecc;
+      Ecc.LOW = new _Ecc(0, 1);
+      Ecc.MEDIUM = new _Ecc(1, 0);
+      Ecc.QUARTILE = new _Ecc(2, 3);
+      Ecc.HIGH = new _Ecc(3, 2);
+      QrCode2.Ecc = Ecc;
+    })(QrCode = qrcodegen2.QrCode || (qrcodegen2.QrCode = {}));
+  })(qrcodegen || (qrcodegen = {}));
+  ((qrcodegen2) => {
+    let QrSegment;
+    ((QrSegment2) => {
+      const _Mode = class {
+        constructor(modeBits, numBitsCharCount) {
+          this.modeBits = modeBits;
+          this.numBitsCharCount = numBitsCharCount;
+        }
+        numCharCountBits(ver) {
+          return this.numBitsCharCount[Math.floor((ver + 7) / 17)];
+        }
+      };
+      let Mode = _Mode;
+      Mode.NUMERIC = new _Mode(1, [10, 12, 14]);
+      Mode.ALPHANUMERIC = new _Mode(2, [9, 11, 13]);
+      Mode.BYTE = new _Mode(4, [8, 16, 16]);
+      Mode.KANJI = new _Mode(8, [8, 10, 12]);
+      Mode.ECI = new _Mode(7, [0, 0, 0]);
+      QrSegment2.Mode = Mode;
+    })(QrSegment = qrcodegen2.QrSegment || (qrcodegen2.QrSegment = {}));
+  })(qrcodegen || (qrcodegen = {}));
+
+  /**
+   * @license qrcode.react
+   * Copyright (c) Paul O'Shannessy
+   * SPDX-License-Identifier: ISC
+   */
+  function generatePath(modules, margin = 0) {
+    const ops = [];
+    modules.forEach(function(row, y) {
+      let start = null;
+      row.forEach(function(cell, x) {
+        if (!cell && start !== null) {
+          ops.push(`M${start + margin} ${y + margin}h${x - start}v1H${start + margin}z`);
+          start = null;
+          return;
+        }
+        if (x === row.length - 1) {
+          if (!cell) {
+            return;
+          }
+          if (start === null) {
+            ops.push(`M${x + margin},${y + margin} h1v1H${x + margin}z`);
+          } else {
+            ops.push(`M${start + margin},${y + margin} h${x + 1 - start}v1H${start + margin}z`);
+          }
+          return;
+        }
+        if (cell && start === null) {
+          start = x;
+        }
+      });
+    });
+    return ops.join("");
+  }
+
+  function renderZip321QrDataUrl(text) {
+    const modules = qrcodegen.QrCode.encodeText(
+      text,
+      qrcodegen.QrCode.Ecc.MEDIUM,
+    ).getModules();
+    const margin = 4;
+    const numCells = modules.length + margin * 2;
+    const size = 240;
+
+    const canvas = document.createElement("canvas");
+    canvas.width = canvas.height = size;
+    const ctx = canvas.getContext("2d");
+    const scale = size / numCells;
+    ctx.scale(scale, scale);
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, numCells, numCells);
+    ctx.fillStyle = "#000000";
+
+    if (typeof Path2D !== "undefined") {
+      ctx.fill(new Path2D(generatePath(modules, margin)));
+    } else {
+      modules.forEach((row, y) => {
+        row.forEach((cell, x) => {
+          if (cell) ctx.fillRect(x + margin, y + margin, 1, 1);
+        });
+      });
+    }
+
+    return canvas.toDataURL("image/png");
+  }
+  // ---------- End vendored QR code generator ----------
+
   // ---------- Configuration ----------
   const DEFAULT_API_BASE =
     typeof window !== "undefined" &&
@@ -156,6 +825,7 @@
       const uri = `zcash:${address}?amount=${amount}${
         memo ? `&memo=${encodeURIComponent(memo)}` : ""
       }`;
+      const qrDataUrl = renderZip321QrDataUrl(uri);
 
       overlay = document.createElement("div");
       overlay.className = "zwg-overlay";
@@ -171,7 +841,7 @@
           </div>
 
           <div class="zwg-qr">
-             <img src="${apiBase}/payment-request-uri/qrcode?data=${encodeURIComponent(uri)}&size=240x240" alt="QR Code "/>
+             <img src="${qrDataUrl}" alt="QR Code "/>
           </div>
 
           <div class="zwg-amt">

--- a/src/lib/__tests__/zcashPaymentWidgetEmbedQr.test.ts
+++ b/src/lib/__tests__/zcashPaymentWidgetEmbedQr.test.ts
@@ -1,0 +1,136 @@
+import fs from "fs";
+import path from "path";
+import jsQR from "jsqr";
+
+/**
+ * Verifies the QR encoder actually vendored into
+ * public/zcash-payment-request-widget.embed.v2.js (not a re-implementation)
+ * produces modules that decode back to the exact original ZIP-321 URI. The
+ * widget generates this QR entirely client-side, so this test also guards
+ * against regressions that would reintroduce a network round trip for QR
+ * generation.
+ */
+
+const EMBED_SCRIPT_PATH = path.join(
+  process.cwd(),
+  "public",
+  "zcash-payment-request-widget.embed.v2.js",
+);
+
+const BEGIN_MARKER =
+  "// ---------- Vendored QR code generator (100% client-side; no network call) ----------";
+const END_MARKER = "// ---------- End vendored QR code generator ----------";
+
+function loadVendoredQrcodegen() {
+  const source = fs.readFileSync(EMBED_SCRIPT_PATH, "utf8");
+  const start = source.indexOf(BEGIN_MARKER);
+  const end = source.indexOf(END_MARKER);
+
+  if (start === -1 || end === -1) {
+    throw new Error(
+      "Could not locate vendored QR generator markers in embed script",
+    );
+  }
+
+  const vendoredSource = source.slice(start, end);
+
+  // eslint-disable-next-line no-new-func
+  const factory = new Function(`${vendoredSource}\nreturn { qrcodegen };`);
+  return factory() as { qrcodegen: any };
+}
+
+function modulesToBitmap(
+  modules: boolean[][],
+  pxPerModule: number,
+  marginModules: number,
+) {
+  const n = modules.length;
+  const totalModules = n + marginModules * 2;
+  const width = totalModules * pxPerModule;
+  const height = width;
+  const data = new Uint8ClampedArray(width * height * 4);
+  data.fill(255); // white background (quiet zone included)
+
+  for (let y = 0; y < n; y++) {
+    for (let x = 0; x < n; x++) {
+      if (!modules[y][x]) continue;
+
+      const px0 = (x + marginModules) * pxPerModule;
+      const py0 = (y + marginModules) * pxPerModule;
+
+      for (let dy = 0; dy < pxPerModule; dy++) {
+        for (let dx = 0; dx < pxPerModule; dx++) {
+          const idx = ((py0 + dy) * width + (px0 + dx)) * 4;
+          data[idx] = 0;
+          data[idx + 1] = 0;
+          data[idx + 2] = 0;
+          data[idx + 3] = 255;
+        }
+      }
+    }
+  }
+
+  return { data, width, height };
+}
+
+function decodeViaVendoredEncoder(qrcodegen: any, text: string): string {
+  const modules = qrcodegen.QrCode.encodeText(
+    text,
+    qrcodegen.QrCode.Ecc.MEDIUM,
+  ).getModules();
+  const { data, width, height } = modulesToBitmap(modules, 6, 4);
+  const result = jsQR(data, width, height);
+
+  if (!result) {
+    throw new Error("jsQR failed to decode the generated QR modules");
+  }
+
+  return result.data;
+}
+
+describe("vendored QR generator in zcash-payment-request-widget.embed.v2.js", () => {
+  const { qrcodegen } = loadVendoredQrcodegen();
+
+  it("exposes the expected encodeText/Ecc/getModules API", () => {
+    expect(typeof qrcodegen.QrCode.encodeText).toBe("function");
+    expect(qrcodegen.QrCode.Ecc.MEDIUM).toBeDefined();
+  });
+
+  it("decodes a simple single-recipient URI", () => {
+    const uri = "zcash:t1VpMigELggqi6TBghQNehqspAcBBDYvRQC?amount=1.5";
+    expect(decodeViaVendoredEncoder(qrcodegen, uri)).toBe(uri);
+  });
+
+  it("decodes a URI with amount and label", () => {
+    const uri =
+      "zcash:t1VpMigELggqi6TBghQNehqspAcBBDYvRQC?amount=0.5&label=Alice";
+    expect(decodeViaVendoredEncoder(qrcodegen, uri)).toBe(uri);
+  });
+
+  it("decodes a URI with base64url-encoded memo content", () => {
+    const memo = Buffer.from("Thanks for the coffee! 🛡️", "utf8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const uri = `zcash:zs1znewaqucqpc372x6ajmfnmkmxsafnc3fuxmg6g5kq3mkvkv8ufx9hgx9vgcrqncqm3umz56a7pd?amount=1.25&memo=${memo}`;
+    expect(decodeViaVendoredEncoder(qrcodegen, uri)).toBe(uri);
+  });
+
+  it("decodes a long payload at the 512-byte memo boundary", () => {
+    const memo = Buffer.from("A".repeat(512), "utf8")
+      .toString("base64")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    const uri = `zcash:zs1znewaqucqpc372x6ajmfnmkmxsafnc3fuxmg6g5kq3mkvkv8ufx9hgx9vgcrqncqm3umz56a7pd?amount=2.0&memo=${memo}`;
+    expect(uri.length).toBeGreaterThan(700);
+    expect(decodeViaVendoredEncoder(qrcodegen, uri)).toBe(uri);
+  });
+
+  it("decodes a multi-recipient-shaped payload (encoder is payload-agnostic; the embed widget itself only emits single-recipient URIs today)", () => {
+    const uri =
+      "zcash:?address=zs1znewaqucqpc372x6ajmfnmkmxsafnc3fuxmg6g5kq3mkvkv8ufx9hgx9vgcrqncqm3umz56a7pd&amount=0.25&address.1=t1VpMigELggqi6TBghQNehqspAcBBDYvRQC&amount.1=0.75";
+    expect(decodeViaVendoredEncoder(qrcodegen, uri)).toBe(uri);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7842,6 +7842,11 @@ jsonwebtoken@^9.0.2:
     ms "^2.1.1"
     semver "^7.5.4"
 
+jsqr@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jsqr/-/jsqr-1.4.0.tgz#8efb8d0a7cc6863cb6d95116b9069123ce9eb2d1"
+  integrity sha512-dxLob7q65Xg2DvstYkRpkYtmKm2sPJ9oFhrhmudT1dZvNFFTlroai3AWSpLey/w5vMcLBXRgOJsbXpdN9HzU/A==
+
 "jsx-ast-utils@^2.4.1 || ^3.0.0", jsx-ast-utils@^3.3.5:
   version "3.3.5"
   resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz#4766bd05a8e2a11af222becd19e15575e52a853a"


### PR DESCRIPTION
## Privacy problem
The embedded payment widget previously sent the full ZIP-321 payment URI to `/api/payment-request-uri/qrcode` in a GET query string. That could expose recipient, amount, label, and memo through URLs, logs, browser history, and caches.

## Fix
Generate the QR code entirely inside the browser using the vendored QR encoder. No payment data is sent over the network for QR generation.

## Scope
- Production behavior change is limited to `public/zcash-payment-request-widget.embed.v2.js`.
- `jsqr` is dev-only and used solely for decode-verification tests.
- No files touched by PR #810 are modified.

## Testing
- Exact vendored encoder output is decoded back to the original ZIP-321 URI.
- Representative simple, amount/label, memo, long-payload, and multi-recipient-shaped cases pass.
- Full Jest suite: 15 suites / 136 tests passed.
- ESLint clean.
- `git diff --check` clean.
- Production embed script passes `node --check`.

## Attribution
Preserves and clearly labels the upstream MIT (Project Nayuki's `qrcodegen`) and ISC (`qrcode.react`'s `generatePath` helper) license headers included with the vendored QR implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sXn8ePeRtesmkUXhEdL7s