### PR TITLE
fix(payment-widget): prevent HTML injection in embed DOM

### DIFF
--- a/public/zcash-payment-request-widget.embed.v2.js
+++ b/public/zcash-payment-request-widget.embed.v2.js
@@ -76,6 +76,30 @@
     ext: `<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3"/></svg>`,
   };
 
+  // DOM helpers. Host-supplied values (label, address, memo, URI) and API
+  // responses are only ever inserted as text nodes or element properties,
+  // never parsed as HTML.
+  function el(tag, className, ...children) {
+    const node = document.createElement(tag);
+    if (className) node.className = className;
+    for (const child of children) {
+      if (child == null || child === false) continue;
+      node.append(
+        typeof child === "string" || typeof child === "number"
+          ? document.createTextNode(String(child))
+          : child,
+      );
+    }
+    return node;
+  }
+
+  // Only ever called with the constant SVG strings from `ic` above.
+  function svg(markup) {
+    const tpl = document.createElement("template");
+    tpl.innerHTML = markup;
+    return tpl.content.firstElementChild;
+  }
+
   async function getZecUsdRate(zecUsdRate, apiBase) {
     const url = `${apiBase}/payment-request-uri/zcash-price-feed`;
 
@@ -136,7 +160,7 @@
     // Create trigger button
     const btn = document.createElement("button");
     btn.className = "zwg-btn";
-    btn.innerHTML = `${ic.z}<span>${label}</span>`;
+    btn.append(svg(ic.z), el("span", null, label));
     container.appendChild(btn);
 
     if (isDisabled) {
@@ -162,64 +186,92 @@
 
       const cls = theme === "dark" ? "zwg-dark" : "zwg-light";
 
-      overlay.innerHTML = `
-        <div class="zwg-modal ${cls}">
-          <button class="zwg-x" aria-label="Close">${ic.x}</button>
-          <div class="zwg-head">
-            <div class="zwg-icon">Z</div>
-            ${label ? `<h2 class="zwg-title">${label}</h2>` : "Pay with Zcash"}
-          </div>
+      const closeX = el("button", "zwg-x", svg(ic.x));
+      closeX.setAttribute("aria-label", "Close");
 
-          <div class="zwg-qr">
-             <img src="${apiBase}/payment-request-uri/qrcode?data=${encodeURIComponent(uri)}&size=240x240" alt="QR Code "/>
-          </div>
+      const qrImg = el("img");
+      qrImg.src = `${apiBase}/payment-request-uri/qrcode?data=${encodeURIComponent(uri)}&size=240x240`;
+      qrImg.alt = "QR Code ";
 
-          <div class="zwg-amt">
-            <p class="zwg-amt-lbl">Amount Due</p>
-            <p class="zwg-amt-val"><b>${Number(amount).toFixed(3)}</b><small>ZEC</small></p>${
-              usdValue
-                ? `<p style="margin-top:4px;font-size:12px;font-style:italic;color:var(--zwg-muted)">
-         ≈ $${usdValue} USD
-       </p>`
-                : ""
-            }
-          </div>
+      let usdEl = null;
+      if (usdValue) {
+        usdEl = el("p", null, `≈ $${usdValue} USD`);
+        usdEl.style.cssText =
+          "margin-top:4px;font-size:12px;font-style:italic;color:var(--zwg-muted)";
+      }
 
-          <div class="zwg-fld">
-            <span class="zwg-fld-lbl">Address</span>
-            <div class="zwg-fld-row">
-              <p class="zwg-fld-txt">${address}</p>
-              <button class="zwg-copy" data-c="${address}">${ic.cp}</button>
-            </div>
-          </div>
+      const addressCopy = el("button", "zwg-copy", svg(ic.cp));
+      addressCopy.dataset.c = address;
 
-          ${
-            memo
-              ? `<div class="zwg-fld">
-                   <span class="zwg-fld-lbl">Memo</span>
-                   <div class="zwg-memo">${memo}</div>
-                 </div>`
-              : ""
-          }
+      const uriInput = el("input", "zwg-fld-inp");
+      uriInput.value = uri;
+      uriInput.readOnly = true;
 
-          <div class="zwg-fld">
-            <span class="zwg-fld-lbl">Payment URI</span>
-            <div class="zwg-fld-row">
-              <input class="zwg-fld-inp" value="${uri}" readonly />
-              <button class="zwg-copy" data-c="${uri}">${ic.cp}</button>
-            </div>
-          </div>
+      const uriCopy = el("button", "zwg-copy", svg(ic.cp));
+      uriCopy.dataset.c = uri;
 
-          <div class="zwg-acts">
-            <button class="zwg-btn2 zwg-sec zwg-close">Close</button>
-            <button class="zwg-btn2 zwg-pri zwg-short">${ic.lnk} Short URL</button>
-          </div>
+      const walletLink = el("a", "zwg-link", svg(ic.ext), " Open in Wallet");
+      walletLink.href = uri;
 
-          <a href="${uri}" class="zwg-link">${ic.ext} Open in Wallet</a>
-          <footer class="zwg-footer"> ${new Date().getFullYear()} Pay with Zcash</footer>
-        </div>
-
-      `;
+      overlay.append(
+        el(
+          "div",
+          `zwg-modal ${cls}`,
+          closeX,
+          el(
+            "div",
+            "zwg-head",
+            el("div", "zwg-icon", "Z"),
+            label ? el("h2", "zwg-title", label) : "Pay with Zcash",
+          ),
+          el("div", "zwg-qr", qrImg),
+          el(
+            "div",
+            "zwg-amt",
+            el("p", "zwg-amt-lbl", "Amount Due"),
+            el(
+              "p",
+              "zwg-amt-val",
+              el("b", null, Number(amount).toFixed(3)),
+              el("small", null, "ZEC"),
+            ),
+            usdEl,
+          ),
+          el(
+            "div",
+            "zwg-fld",
+            el("span", "zwg-fld-lbl", "Address"),
+            el(
+              "div",
+              "zwg-fld-row",
+              el("p", "zwg-fld-txt", address),
+              addressCopy,
+            ),
+          ),
+          memo
+            ? el(
+                "div",
+                "zwg-fld",
+                el("span", "zwg-fld-lbl", "Memo"),
+                el("div", "zwg-memo", memo),
+              )
+            : null,
+          el(
+            "div",
+            "zwg-fld",
+            el("span", "zwg-fld-lbl", "Payment URI"),
+            el("div", "zwg-fld-row", uriInput, uriCopy),
+          ),
+          el(
+            "div",
+            "zwg-acts",
+            el("button", "zwg-btn2 zwg-sec zwg-close", "Close"),
+            el("button", "zwg-btn2 zwg-pri zwg-short", svg(ic.lnk), " Short URL"),
+          ),
+          walletLink,
+          el("footer", "zwg-footer", ` ${new Date().getFullYear()} Pay with Zcash`),
+        ),
+      );
 
       document.body.appendChild(overlay);
 
@@ -256,15 +308,19 @@
           const { shortUrl } = await res.json();
           shortBtn.innerHTML = `${ic.ok} Done`;
 
-          const fld = document.createElement("div");
-          fld.className = "zwg-fld";
-          fld.innerHTML = `
-            <span class="zwg-fld-lbl">Short URL</span>
-            <div class="zwg-fld-row">
-              <input class="zwg-fld-inp" value="${shortUrl}" readonly />
-              <button class="zwg-copy" data-c="${shortUrl}">${ic.cp}</button>
-            </div>
-          `;
+          const shortInput = el("input", "zwg-fld-inp");
+          shortInput.value = shortUrl;
+          shortInput.readOnly = true;
+
+          const shortCopy = el("button", "zwg-copy", svg(ic.cp));
+          shortCopy.dataset.c = shortUrl;
+
+          const fld = el(
+            "div",
+            "zwg-fld",
+            el("span", "zwg-fld-lbl", "Short URL"),
+            el("div", "zwg-fld-row", shortInput, shortCopy),
+          );
 
           overlay.querySelector(".zwg-acts").before(fld);
 

--- a/src/lib/__tests__/zcashPaymentWidgetEmbedDom.test.ts
+++ b/src/lib/__tests__/zcashPaymentWidgetEmbedDom.test.ts
@@ -1,0 +1,180 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Regression tests for HTML injection in the embeddable payment widget.
+ * Loads the real public/zcash-payment-request-widget.embed.v2.js into jsdom
+ * and feeds it hostile host-supplied values and API responses, asserting
+ * they are rendered strictly as data (text nodes / properties) and never
+ * parsed as markup.
+ */
+
+const EMBED_SCRIPT_PATH = path.join(
+  process.cwd(),
+  "public",
+  "zcash-payment-request-widget.embed.v2.js",
+);
+
+const HOSTILE_SELECTOR =
+  "[onerror],[onmouseover],[onload],[onclick],script,#injected";
+
+type WidgetInstance = {
+  open: () => void;
+  close: () => void;
+  destroy: () => void;
+};
+
+type RenderFn = (
+  selector: string,
+  opts: Record<string, unknown>,
+) => Promise<WidgetInstance | null | undefined>;
+
+function renderZcashButton(): RenderFn {
+  return (window as unknown as { renderZcashButton: RenderFn })
+    .renderZcashButton;
+}
+
+async function render(opts: Record<string, unknown>) {
+  document.body.innerHTML = '<div id="target"></div>';
+  const inst = await renderZcashButton()("#target", {
+    amount: 1,
+    zecUsdRate: 1,
+    apiBase: "https://zechub.wiki/api",
+    ...opts,
+  });
+  if (!inst) throw new Error("widget did not render");
+  return inst;
+}
+
+function overlay(): HTMLElement {
+  const node = document.querySelector<HTMLElement>(".zwg-overlay");
+  if (!node) throw new Error("overlay not open");
+  return node;
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+beforeAll(() => {
+  const source = fs.readFileSync(EMBED_SCRIPT_PATH, "utf8");
+  // eslint-disable-next-line no-new-func
+  new Function(source)();
+});
+
+beforeEach(() => {
+  (global as unknown as { fetch: unknown }).fetch = jest.fn();
+});
+
+describe("zcash-payment-request-widget.embed.v2.js DOM construction", () => {
+  it("renders a label containing markup as text on the trigger button and modal title", async () => {
+    const label = 'Pay <img src=x onerror=alert(1)> <script id="injected"></script>';
+    const inst = await render({ address: "t1VpMigELggqi6TBghQNehqspAcBBDYvRQC", label });
+
+    const btn = document.querySelector<HTMLElement>(".zwg-btn")!;
+    expect(btn.querySelector("span")!.textContent).toBe(label);
+    expect(btn.querySelector(HOSTILE_SELECTOR)).toBeNull();
+    expect(btn.querySelector("svg")).not.toBeNull();
+
+    inst.open();
+    expect(overlay().querySelector(".zwg-title")!.textContent).toBe(label);
+    expect(overlay().querySelector(HOSTILE_SELECTOR)).toBeNull();
+  });
+
+  it("renders a memo containing markup as text", async () => {
+    const memo = 'note <b id="injected">bold</b><img src=x onerror=alert(2)>';
+    const inst = await render({
+      address: "zs1znewaqucqpc372x6ajmfnmkmxsafnc3fuxmg6g5kq3mkvkv8ufx9hgx9vgcrqncqm3umz56a7pd",
+      memo,
+    });
+    inst.open();
+
+    expect(overlay().querySelector(".zwg-memo")!.textContent).toBe(memo);
+    expect(overlay().querySelector(HOSTILE_SELECTOR)).toBeNull();
+    expect(overlay().querySelectorAll("img")).toHaveLength(1); // only the QR image
+  });
+
+  it("keeps an address with quotes intact and blocks attribute injection", async () => {
+    const address = 't1abc" onmouseover="alert(1)';
+    const inst = await render({ address });
+    inst.open();
+
+    const uri = `zcash:${address}?amount=1`;
+    const copyButtons = overlay().querySelectorAll<HTMLElement>(".zwg-copy");
+
+    expect(overlay().querySelector(".zwg-fld-txt")!.textContent).toBe(address);
+    expect(copyButtons[0].dataset.c).toBe(address);
+    expect(copyButtons[1].dataset.c).toBe(uri);
+    expect(overlay().querySelector<HTMLInputElement>(".zwg-fld-inp")!.value).toBe(uri);
+    expect(overlay().querySelector(".zwg-link")!.getAttribute("href")).toBe(uri);
+    expect(overlay().querySelector(HOSTILE_SELECTOR)).toBeNull();
+  });
+
+  it("treats a hostile shortUrl API response as data", async () => {
+    const shortUrl = '"><img src=x onerror=alert(1)><b id="injected">x</b>';
+    (global as unknown as { fetch: jest.Mock }).fetch.mockResolvedValue({
+      json: async () => ({ shortUrl }),
+    });
+
+    const inst = await render({ address: "t1VpMigELggqi6TBghQNehqspAcBBDYvRQC" });
+    inst.open();
+    overlay().querySelector<HTMLButtonElement>(".zwg-short")!.click();
+    await flush();
+    await flush();
+
+    const inputs = overlay().querySelectorAll<HTMLInputElement>(".zwg-fld-inp");
+    const copyButtons = overlay().querySelectorAll<HTMLElement>(".zwg-copy");
+    expect(inputs).toHaveLength(2);
+    expect(inputs[1].value).toBe(shortUrl);
+    expect(copyButtons[copyButtons.length - 1].dataset.c).toBe(shortUrl);
+    expect(overlay().querySelector(HOSTILE_SELECTOR)).toBeNull();
+    expect(overlay().querySelectorAll("img")).toHaveLength(1);
+  });
+
+  it("still renders and behaves normally for legitimate values", async () => {
+    const address = "t1VpMigELggqi6TBghQNehqspAcBBDYvRQC";
+    const inst = await render({
+      address,
+      amount: 1.5,
+      zecUsdRate: 2,
+      label: "Coffee",
+      memo: "Thanks!",
+      theme: "dark",
+    });
+
+    expect(document.querySelector(".zwg-btn span")!.textContent).toBe("Coffee");
+
+    inst.open();
+    const modal = overlay().querySelector(".zwg-modal")!;
+    expect(modal.classList.contains("zwg-dark")).toBe(true);
+    expect(modal.querySelector(".zwg-x")!.getAttribute("aria-label")).toBe("Close");
+    expect(modal.querySelector(".zwg-amt-val b")!.textContent).toBe("1.500");
+    expect(modal.querySelector(".zwg-amt-val small")!.textContent).toBe("ZEC");
+    expect(modal.querySelector(".zwg-amt")!.textContent).toContain("≈ $3.00 USD");
+    expect(modal.querySelector(".zwg-fld-txt")!.textContent).toBe(address);
+    expect(modal.querySelector(".zwg-memo")!.textContent).toBe("Thanks!");
+    expect(modal.querySelector<HTMLInputElement>(".zwg-fld-inp")!.readOnly).toBe(true);
+    expect(modal.querySelector<HTMLInputElement>(".zwg-fld-inp")!.value).toBe(
+      `zcash:${address}?amount=1.5&memo=Thanks!`,
+    );
+    expect(modal.querySelector<HTMLImageElement>(".zwg-qr img")!.getAttribute("src")).toContain(
+      "/payment-request-uri/qrcode?data=",
+    );
+    expect(modal.querySelector(".zwg-footer")!.textContent).toContain("Pay with Zcash");
+
+    modal.querySelector<HTMLButtonElement>(".zwg-close")!.click();
+    expect(document.querySelector(".zwg-overlay")).toBeNull();
+
+    inst.open();
+    expect(document.querySelector(".zwg-overlay")).not.toBeNull();
+    overlay().querySelector<HTMLButtonElement>(".zwg-x")!.click();
+    expect(document.querySelector(".zwg-overlay")).toBeNull();
+
+    inst.destroy();
+    expect(document.querySelector(".zwg-btn")).toBeNull();
+  });
+
+  it("omits the memo block when no memo is given", async () => {
+    const inst = await render({ address: "t1VpMigELggqi6TBghQNehqspAcBBDYvRQC" });
+    inst.open();
+    expect(overlay().querySelector(".zwg-memo")).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem
Dynamic values such as label, address, memo, payment URI, and shortUrl were inserted into `innerHTML`, allowing attacker-controlled markup/attributes to be parsed in the embedding site's origin.

## Fix
Replace dynamic `innerHTML` construction with safe DOM APIs such as `document.createElement`, text nodes, `.value`, `.dataset`, `.href`, `.src`, and `append`.

## Scope
- Production change is limited to `public/zcash-payment-request-widget.embed.v2.js` plus the new regression test.
- Constant-only SVG/icon HTML remains unchanged.
- ZIP-321 URI construction is unchanged.
- No files from PR #809 or PR #810 are touched.

## Tests
- Hostile label, memo, address, and shortUrl cases are covered.
- The regression tests fail against the original vulnerable script and pass with this fix.
- Targeted tests: 6/6 passed.
- Full Jest suite: 15 suites / 136 tests passed.
- ESLint clean.
- `node --check` passes.
- `git diff --check` clean.

## Related PRs / suggested merge order

This PR is part of the payment-widget hardening bounty, split into six focused PRs.

Recommended merge order:

`#810 -> #814 / #818 / #823 -> #817 -> #819 -> #815`

1. #810 (not mine) should preferably land first to keep haruu99's changes separate and easy to review.
2. #814, #818, and #823 are mutually non-conflicting and can land in any order.
3. #817 provides the safer embed-DOM base.
4. #819 has been verified to merge cleanly on top of #817.
5. #815 is last in the suggested order; see the note below.

## Note

PR [#815](https://github.com/ZecHub/zechub-wiki/pull/815) modifies the same `open()` region for client-side QR generation, so whichever PR merges second may require a small rebase/conflict resolution. This PR intentionally does not incorporate [#815](https://github.com/ZecHub/zechub-wiki/pull/815).
## Note
PR #815 modifies the same `open()` region for client-side QR generation, so whichever PR merges second may require a small rebase/conflict resolution. This PR intentionally does not incorporate #815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sXn8ePeRtesmkUXhEdL7s