### PR TITLE
fix(api): harden payment request endpoints

### DIFF
--- a/src/app/api/payment-request-uri/shorten/route.ts
+++ b/src/app/api/payment-request-uri/shorten/route.ts
@@ -1,16 +1,35 @@
 
 import { config } from "@/app/[locale]/tools/zcash-payment-widget/config";
+import { readBoundedJsonBody } from "@/lib/apiRequestGuards";
 import { nanoid } from "nanoid";
 import { NextRequest, NextResponse } from "next/server";
 
+const MAX_URI_LENGTH = 4096;
+export const MAX_STORE_ENTRIES = 10_000;
+
 // TODO: Using memory store (can be changed to db)
-export const urlStore: Record<string, string> = {}; // shortId => full URI
+export const urlStore = new Map<string, string>(); // shortId => full URI
+
+function storeUri(shortId: string, uri: string) {
+  if (urlStore.size >= MAX_STORE_ENTRIES) {
+    const oldestKey = urlStore.keys().next().value;
+    if (oldestKey !== undefined) urlStore.delete(oldestKey);
+  }
+  urlStore.set(shortId, uri);
+}
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": `${config.env.ACCESS_CONTROL_ALLOW_ORIGIN}`,
   "Access-Control-Allow-Methods": "POST, OPTIONS",
   "ACCESS-CONTROL-ALLOW-HEADERS": "CONTENT-TYPE",
 };
+
+function jsonWithCors(data: unknown, status: number) {
+  return NextResponse.json(data, {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+}
 
 export async function OPTIONS(req: NextRequest) {
   return new NextResponse(null, {
@@ -20,34 +39,28 @@ export async function OPTIONS(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  try {
-    const body = await req.json();
-    const { uri } = body;
-
-    if (!uri) {
-      return NextResponse.json({ error: "Missing uri" }, { status: 400 });
-    }
-
-    const shortId = nanoid(8);
-    urlStore[shortId] = uri;
-
-    const url = config.env.NEXT_PUBLIC_WIDGET_API_BASE_URL;
-    const shortUrl = `${url}/api/payment-request-uri/shorten/${shortId}`;
-
-    return NextResponse.json(
-      { shortUrl },
-      {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-          ...corsHeaders,
-        },
-      },
-    );
-  } catch (err) {
-    const msg =
-      err instanceof Error ? err.message : "Failed process payment uri.";
-
-    return NextResponse.json({ error: JSON.parse(msg) }, { status: 500 });
+  const result = await readBoundedJsonBody<{ uri?: unknown }>(req);
+  if (!result.ok) {
+    return jsonWithCors({ error: result.error }, result.status);
   }
+
+  const { uri } = result.body ?? {};
+
+  if (typeof uri !== "string" || uri.length === 0) {
+    return jsonWithCors({ error: "Missing uri" }, 400);
+  }
+  if (uri.length > MAX_URI_LENGTH) {
+    return jsonWithCors(
+      { error: `uri exceeds maximum length of ${MAX_URI_LENGTH} characters` },
+      413,
+    );
+  }
+
+  const shortId = nanoid(8);
+  storeUri(shortId, uri);
+
+  const url = config.env.NEXT_PUBLIC_WIDGET_API_BASE_URL;
+  const shortUrl = `${url}/api/payment-request-uri/shorten/${shortId}`;
+
+  return jsonWithCors({ shortUrl }, 200);
 }

--- a/src/app/api/payment-request-uri/widget-telemetry/route.ts
+++ b/src/app/api/payment-request-uri/widget-telemetry/route.ts
@@ -1,12 +1,16 @@
-import { NextRequest } from "next/server";
+import { readBoundedJsonBody } from "@/lib/apiRequestGuards";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
- * Zcash payment request telemetry endpoint 
- * @param req 
+ * Zcash payment request telemetry endpoint
+ * @param req
  */
 export async function POST(req: NextRequest) {
   // TODO: requires full implementation
-  const body = req.json();
+  const result = await readBoundedJsonBody(req);
+  if (!result.ok) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
 
-  console.log(body);
+  return new NextResponse(null, { status: 204 });
 }

--- a/src/app/api/payment-request-uri/zcash-price-feed/route.ts
+++ b/src/app/api/payment-request-uri/zcash-price-feed/route.ts
@@ -1,47 +1,65 @@
+import { readBoundedJsonBody } from "@/lib/apiRequestGuards";
 import { NextRequest, NextResponse } from "next/server";
 import { priceFeedBodySchema } from "./schema/price-feed-body.schema";
 import { getZcashPrice } from "./utils/get-zec-price";
 
 const priceFeedUrl = String(process.env.BASE_URL_ZCASH_PRICE_FEED);
 
+function priceUnavailable() {
+  return NextResponse.json(
+    { error: "Zcash price is currently unavailable" },
+    { status: 503 },
+  );
+}
+
 export async function GET(req: NextRequest) {
-  try {
-    const { price, source } = await getZcashPrice(priceFeedUrl);
+  const { price, source } = await getZcashPrice(priceFeedUrl);
 
-    return NextResponse.json(
-      { data: { rate: price, source } },
-      { status: 200 },
-    );
-  } catch (err) {
-    const errMsg = err instanceof Error ? err.message : "Invalid request";
-
-    return NextResponse.json({ error: JSON.parse(errMsg) }, { status: 500 });
+  if (!(price > 0)) {
+    return priceUnavailable();
   }
+
+  return NextResponse.json(
+    { data: { rate: price, source } },
+    { status: 200 },
+  );
 }
 
 export async function POST(req: NextRequest) {
-  try {
-    const body = await req.json();
-
-    const { amount, from, to } = priceFeedBodySchema.parse(body);
-    const { price, source } = await getZcashPrice(priceFeedUrl);
-
-    let result: number;
-    if (from === "usd" && to === "zec") {
-      result = amount / price;
-    } else if (from === "zec" && to === "usd") {
-      result = amount * price;
-    } else {
-      result = amount;
-    }
-
+  const bodyResult = await readBoundedJsonBody(req);
+  if (!bodyResult.ok) {
     return NextResponse.json(
-      { data: { amount: result, rate: price, source } },
-      { status: 200 },
+      { error: bodyResult.error },
+      { status: bodyResult.status },
     );
-  } catch (err) {
-    const errMsg = err instanceof Error ? err.message : "Invalid request";
-
-    return NextResponse.json({ error: JSON.parse(errMsg) }, { status: 500 });
   }
+
+  const parsed = priceFeedBodySchema.safeParse(bodyResult.body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: parsed.error.issues[0]?.message || "Invalid request payload" },
+      { status: 400 },
+    );
+  }
+
+  const { amount, from, to } = parsed.data;
+  const { price, source } = await getZcashPrice(priceFeedUrl);
+
+  if (!(price > 0)) {
+    return priceUnavailable();
+  }
+
+  let convertedAmount: number;
+  if (from === "usd" && to === "zec") {
+    convertedAmount = amount / price;
+  } else if (from === "zec" && to === "usd") {
+    convertedAmount = amount * price;
+  } else {
+    convertedAmount = amount;
+  }
+
+  return NextResponse.json(
+    { data: { amount: convertedAmount, rate: price, source } },
+    { status: 200 },
+  );
 }

--- a/src/app/api/payment-request-uri/zcash-price-feed/schema/price-feed-body.schema.ts
+++ b/src/app/api/payment-request-uri/zcash-price-feed/schema/price-feed-body.schema.ts
@@ -1,7 +1,9 @@
 import { z } from "zod";
 
+const MAX_AMOUNT = 1_000_000_000;
+
 export const priceFeedBodySchema = z.object({
-  amount: z.coerce.number().positive(),
+  amount: z.coerce.number().positive().max(MAX_AMOUNT),
   from: z.enum(["usd", "zec"]),
   to: z.enum(["usd", "zec"]),
 });

--- a/src/app/api/payment-request-uri/zcash-price-feed/utils/get-zec-price.ts
+++ b/src/app/api/payment-request-uri/zcash-price-feed/utils/get-zec-price.ts
@@ -2,6 +2,15 @@ let lastKnownPrice = 0;
 let lastUpdated = 0;
 let src = "";
 
+const UPSTREAM_TIMEOUT_MS = 5000;
+
+/**
+ * Fetches the current ZEC price. On any upstream failure (timeout,
+ * non-2xx, invalid payload), falls back to the last known-good price so
+ * transient upstream issues don't break every request; if no usable price
+ * has ever been obtained, returns `price: 0` so callers can surface a 503
+ * instead of a misleading successful zero/null result.
+ */
 export async function getZcashPrice(
   url: string,
   source = "",
@@ -14,16 +23,26 @@ export async function getZcashPrice(
   }
 
   try {
-    const res = await fetch(url);
-    const { Price, Source } = await res.json();
+    const res = await fetch(url, {
+      signal: AbortSignal.timeout(UPSTREAM_TIMEOUT_MS),
+    });
 
-    if (Price > 0) {
-      lastKnownPrice = Number(Price);
-      lastUpdated = now;
-      src = Source;
+    if (!res.ok) {
+      throw new Error(`Upstream price feed responded with ${res.status}`);
     }
 
-    return { price: lastKnownPrice, source: src ?? source };
+    const { Price, Source } = await res.json();
+    const price = Number(Price);
+
+    if (!Number.isFinite(price) || price <= 0) {
+      throw new Error("Upstream price feed returned an invalid price");
+    }
+
+    lastKnownPrice = price;
+    lastUpdated = now;
+    src = typeof Source === "string" ? Source : source;
+
+    return { price: lastKnownPrice, source: src };
   } catch (err) {
     console.error("ZEC price fetch failed:", err);
     return { price: lastKnownPrice || 0, source: src || source };

--- a/src/lib/__tests__/apiRequestGuards.test.ts
+++ b/src/lib/__tests__/apiRequestGuards.test.ts
@@ -1,0 +1,80 @@
+/** @jest-environment node */
+import {
+  MAX_JSON_BODY_BYTES,
+  readBoundedJsonBody,
+} from "../apiRequestGuards";
+
+function makeRequest(
+  body: string,
+  { contentLength }: { contentLength?: number } = {},
+) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (contentLength !== undefined) {
+    headers["content-length"] = String(contentLength);
+  }
+  return new Request("http://localhost/api/test", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("readBoundedJsonBody", () => {
+  it("parses a normal, well within-limit JSON body", async () => {
+    const result = await readBoundedJsonBody(makeRequest('{"a":1,"b":"x"}'));
+    expect(result).toEqual({ ok: true, body: { a: 1, b: "x" } });
+  });
+
+  it("rejects a body declared oversized via Content-Length as 413, without reading it", async () => {
+    const result = await readBoundedJsonBody(
+      makeRequest("{}", { contentLength: MAX_JSON_BODY_BYTES + 1 }),
+    );
+    expect(result).toEqual({
+      ok: false,
+      status: 413,
+      error: expect.any(String),
+    });
+  });
+
+  it("rejects a body that exceeds the limit even without a Content-Length header", async () => {
+    const oversized = JSON.stringify({ data: "a".repeat(MAX_JSON_BODY_BYTES) });
+    const result = await readBoundedJsonBody(makeRequest(oversized));
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(413);
+  });
+
+  it("accepts a body exactly at the limit", async () => {
+    const padding = "a".repeat(
+      MAX_JSON_BODY_BYTES - JSON.stringify({ data: "" }).length,
+    );
+    const atLimit = JSON.stringify({ data: padding });
+    expect(Buffer.byteLength(atLimit, "utf8")).toBe(MAX_JSON_BODY_BYTES);
+
+    const result = await readBoundedJsonBody(makeRequest(atLimit));
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects malformed JSON as 400", async () => {
+    const result = await readBoundedJsonBody(makeRequest("{not valid json"));
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: expect.any(String),
+    });
+  });
+
+  it("rejects an empty body as 400", async () => {
+    const result = await readBoundedJsonBody(makeRequest(""));
+    expect(result).toEqual({
+      ok: false,
+      status: 400,
+      error: expect.any(String),
+    });
+  });
+
+  it("honors a custom maxBytes argument", async () => {
+    const result = await readBoundedJsonBody(makeRequest('{"a":1}'), 4);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(413);
+  });
+});

--- a/src/lib/__tests__/shortenRoute.test.ts
+++ b/src/lib/__tests__/shortenRoute.test.ts
@@ -1,0 +1,99 @@
+/** @jest-environment node */
+import { NextRequest } from "next/server";
+
+function postRequest(
+  body: string,
+  { contentLength }: { contentLength?: number } = {},
+) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (contentLength !== undefined) {
+    headers["content-length"] = String(contentLength);
+  }
+  return new NextRequest("http://localhost/api/payment-request-uri/shorten", {
+    method: "POST",
+    headers,
+    body,
+  });
+}
+
+describe("POST /api/payment-request-uri/shorten", () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it("shortens a valid uri and returns CORS headers", async () => {
+    const { POST } = await import("@/app/api/payment-request-uri/shorten/route");
+    const res = await POST(postRequest(JSON.stringify({ uri: "zcash:t1abc?amount=1" })));
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Access-Control-Allow-Origin")).not.toBeNull();
+    const data = await res.json();
+    expect(typeof data.shortUrl).toBe("string");
+    expect(data.shortUrl).toContain("/api/payment-request-uri/shorten/");
+  });
+
+  it("rejects malformed JSON as 400", async () => {
+    const { POST } = await import("@/app/api/payment-request-uri/shorten/route");
+    const res = await POST(postRequest("{not json"));
+    expect(res.status).toBe(400);
+    expect(res.headers.get("Access-Control-Allow-Origin")).not.toBeNull();
+  });
+
+  it("rejects a missing uri as 400", async () => {
+    const { POST } = await import("@/app/api/payment-request-uri/shorten/route");
+    const res = await POST(postRequest(JSON.stringify({})));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a non-string uri as 400", async () => {
+    const { POST } = await import("@/app/api/payment-request-uri/shorten/route");
+    const res = await POST(postRequest(JSON.stringify({ uri: 12345 })));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects an empty-string uri as 400", async () => {
+    const { POST } = await import("@/app/api/payment-request-uri/shorten/route");
+    const res = await POST(postRequest(JSON.stringify({ uri: "" })));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects a uri over the length limit as 413", async () => {
+    const { POST } = await import("@/app/api/payment-request-uri/shorten/route");
+    const uri = "zcash:t1abc?amount=1&memo=" + "a".repeat(4100);
+    const res = await POST(postRequest(JSON.stringify({ uri })));
+    expect(res.status).toBe(413);
+  });
+
+  it("rejects an oversized body as 413 before parsing", async () => {
+    const { POST } = await import("@/app/api/payment-request-uri/shorten/route");
+    const res = await POST(
+      postRequest(JSON.stringify({ uri: "zcash:t1abc" }), { contentLength: 20000 }),
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it("caps the in-memory store at MAX_STORE_ENTRIES with FIFO eviction", async () => {
+    const { POST, urlStore, MAX_STORE_ENTRIES } = await import(
+      "@/app/api/payment-request-uri/shorten/route"
+    );
+
+    urlStore.clear();
+
+    // Fill to exactly the cap.
+    for (let i = 0; i < MAX_STORE_ENTRIES; i++) {
+      const res = await POST(postRequest(JSON.stringify({ uri: `zcash:seed-${i}` })));
+      expect(res.status).toBe(200);
+    }
+    expect(urlStore.size).toBe(MAX_STORE_ENTRIES);
+
+    const oldestKeyBeforeOverflow = urlStore.keys().next().value;
+    expect(oldestKeyBeforeOverflow).toBeDefined();
+
+    // One more insert should evict exactly the oldest entry, not grow the store.
+    const res = await POST(postRequest(JSON.stringify({ uri: "zcash:overflow" })));
+    expect(res.status).toBe(200);
+
+    expect(urlStore.size).toBe(MAX_STORE_ENTRIES);
+    expect(urlStore.has(oldestKeyBeforeOverflow as string)).toBe(false);
+  }, 20000);
+});

--- a/src/lib/__tests__/widgetTelemetryRoute.test.ts
+++ b/src/lib/__tests__/widgetTelemetryRoute.test.ts
@@ -1,0 +1,59 @@
+/** @jest-environment node */
+import { NextRequest } from "next/server";
+
+function postRequest(
+  body: string,
+  { contentLength }: { contentLength?: number } = {},
+) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (contentLength !== undefined) {
+    headers["content-length"] = String(contentLength);
+  }
+  return new NextRequest(
+    "http://localhost/api/payment-request-uri/widget-telemetry",
+    { method: "POST", headers, body },
+  );
+}
+
+describe("POST /api/payment-request-uri/widget-telemetry", () => {
+  it("returns 204 for a valid JSON body", async () => {
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/widget-telemetry/route"
+    );
+    const res = await POST(postRequest(JSON.stringify({ event: "open" })));
+    expect(res.status).toBe(204);
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/widget-telemetry/route"
+    );
+    const res = await POST(postRequest("{not json"));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 413 for an oversized body", async () => {
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/widget-telemetry/route"
+    );
+    const res = await POST(
+      postRequest(JSON.stringify({ event: "open" }), { contentLength: 20000 }),
+    );
+    expect(res.status).toBe(413);
+  });
+
+  it("does not log the raw request body", async () => {
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/widget-telemetry/route"
+    );
+    await POST(postRequest(JSON.stringify({ secret: "should-not-be-logged" })));
+    const loggedSomethingWithSecret = logSpy.mock.calls.some((call) =>
+      call.some(
+        (arg) => typeof arg === "string" && arg.includes("should-not-be-logged"),
+      ),
+    );
+    expect(loggedSomethingWithSecret).toBe(false);
+    logSpy.mockRestore();
+  });
+});

--- a/src/lib/__tests__/zcashPriceFeedRoute.test.ts
+++ b/src/lib/__tests__/zcashPriceFeedRoute.test.ts
@@ -1,0 +1,168 @@
+/** @jest-environment node */
+import { NextRequest } from "next/server";
+
+function postRequest(body: string) {
+  return new NextRequest(
+    "http://localhost/api/payment-request-uri/zcash-price-feed",
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body,
+    },
+  );
+}
+
+function getRequest() {
+  return new NextRequest(
+    "http://localhost/api/payment-request-uri/zcash-price-feed",
+  );
+}
+
+function mockFetchOnce(impl: () => Promise<Response> | Response) {
+  (global as unknown as { fetch: jest.Mock }).fetch = jest.fn(impl);
+}
+
+describe("/api/payment-request-uri/zcash-price-feed", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useRealTimers();
+  });
+
+  it("GET returns the price on a healthy upstream", async () => {
+    mockFetchOnce(
+      () =>
+        new Response(JSON.stringify({ Price: 30, Source: "test" }), {
+          status: 200,
+        }),
+    );
+    const { GET } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await GET(getRequest());
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.data.rate).toBe(30);
+    expect(data.data.source).toBe("test");
+  });
+
+  it("GET returns 503 when the upstream is unreachable and there is no cached price", async () => {
+    mockFetchOnce(() => Promise.reject(new Error("network down")));
+    const { GET } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await GET(getRequest());
+    expect(res.status).toBe(503);
+  });
+
+  it("GET returns 503 when the upstream responds non-2xx", async () => {
+    mockFetchOnce(() => new Response("nope", { status: 500 }));
+    const { GET } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await GET(getRequest());
+    expect(res.status).toBe(503);
+  });
+
+  it("GET returns 503 when the upstream price is not a finite positive number", async () => {
+    mockFetchOnce(
+      () =>
+        new Response(JSON.stringify({ Price: "not-a-number" }), {
+          status: 200,
+        }),
+    );
+    const { GET } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await GET(getRequest());
+    expect(res.status).toBe(503);
+  });
+
+  it("POST converts usd->zec using a healthy upstream price", async () => {
+    mockFetchOnce(
+      () =>
+        new Response(JSON.stringify({ Price: 25, Source: "test" }), {
+          status: 200,
+        }),
+    );
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await POST(
+      postRequest(JSON.stringify({ amount: 50, from: "usd", to: "zec" })),
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.data.amount).toBe(2);
+    expect(data.data.rate).toBe(25);
+  });
+
+  it("POST rejects malformed JSON as 400", async () => {
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await POST(postRequest("{bad"));
+    expect(res.status).toBe(400);
+  });
+
+  it("POST rejects a schema violation as 400 instead of 500", async () => {
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await POST(
+      postRequest(JSON.stringify({ amount: -5, from: "usd", to: "zec" })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("POST rejects an amount above the maximum as 400", async () => {
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await POST(
+      postRequest(
+        JSON.stringify({ amount: 2_000_000_000, from: "usd", to: "zec" }),
+      ),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("POST rejects a non-finite-producing amount (e.g. huge exponent) as 400", async () => {
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await POST(
+      postRequest(JSON.stringify({ amount: 1e308, from: "usd", to: "zec" })),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("POST returns 503 (not a misleading 200) when upstream price is unavailable", async () => {
+    mockFetchOnce(() => Promise.reject(new Error("timeout")));
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const res = await POST(
+      postRequest(JSON.stringify({ amount: 10, from: "usd", to: "zec" })),
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it("POST rejects an oversized body as 413", async () => {
+    const { POST } = await import(
+      "@/app/api/payment-request-uri/zcash-price-feed/route"
+    );
+    const req = new NextRequest(
+      "http://localhost/api/payment-request-uri/zcash-price-feed",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": "20000",
+        },
+        body: JSON.stringify({ amount: 1, from: "usd", to: "zec" }),
+      },
+    );
+    const res = await POST(req);
+    expect(res.status).toBe(413);
+  });
+});

--- a/src/lib/apiRequestGuards.ts
+++ b/src/lib/apiRequestGuards.ts
@@ -1,0 +1,54 @@
+export const MAX_JSON_BODY_BYTES = 16 * 1024;
+
+export type BoundedJsonBodyResult<T = unknown> =
+  | { ok: true; body: T }
+  | { ok: false; status: 400 | 413; error: string };
+
+/**
+ * Reads a request body as JSON, rejecting it before fully buffering when it
+ * exceeds `maxBytes` (via Content-Length when present, and by aborting the
+ * stream early otherwise) rather than relying on JSON.parse to fail after
+ * the whole body has already been read into memory.
+ */
+export async function readBoundedJsonBody<T = unknown>(
+  req: Request,
+  maxBytes: number = MAX_JSON_BODY_BYTES,
+): Promise<BoundedJsonBodyResult<T>> {
+  const declaredLength = Number(req.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > maxBytes) {
+    return { ok: false, status: 413, error: "Request body too large" };
+  }
+
+  if (!req.body) {
+    return { ok: false, status: 400, error: "Missing request body" };
+  }
+
+  const reader = req.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    if (value) {
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => {});
+        return { ok: false, status: 413, error: "Request body too large" };
+      }
+      chunks.push(value);
+    }
+  }
+
+  const raw = Buffer.concat(chunks).toString("utf8");
+  if (raw.length === 0) {
+    return { ok: false, status: 400, error: "Missing request body" };
+  }
+
+  try {
+    return { ok: true, body: JSON.parse(raw) as T };
+  } catch {
+    return { ok: false, status: 400, error: "Invalid JSON body" };
+  }
+}


### PR DESCRIPTION
## Scope
Hardens the non-overlapping payment-request API routes while deliberately avoiding every file touched by PR #810.

## `/shorten`
- 16 KB request-body cap
- malformed JSON → 400
- missing/wrong-type/empty URI → 400
- URI over 4096 chars → 413
- bounded in-memory store with FIFO eviction at 10,000 entries
- 4xx responses include existing CORS headers

## `/zcash-price-feed`
- 16 KB POST body cap
- malformed/schema-invalid requests → 400
- bounded amount input
- 5-second upstream timeout
- non-2xx/invalid upstream data treated as failure
- unavailable price → 503 instead of misleading zero/null 200 responses
- valid successful response shapes unchanged

## `/widget-telemetry`
- fixes missing await / undefined-response behavior
- bounded JSON body
- malformed JSON → 400
- oversized body → 413
- valid request → 204
- removes raw request-body logging

## Shared helper
`src/lib/apiRequestGuards.ts` provides bounded JSON parsing with explicit 400/413 outcomes.

## Tests
- full Jest suite: 18 suites / 160 tests passed
- ESLint clean
- changed/new files TypeScript-clean
- only pre-existing unrelated static-asset TS2307 errors remain
- `git diff --check` clean

## Boundary
GET `/api/payment-request-uri/qrcode`, `qrcode.schema.ts`, and all other PR #810 files are intentionally untouched. The QR size/data-limit findings remain deferred until #810 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sXn8ePeRtesmkUXhEdL7s