### PR TITLE
fix(payment-widget): improve dialog accessibility

### DIFF
--- a/public/zcash-payment-request-widget.embed.v2.js
+++ b/public/zcash-payment-request-widget.embed.v2.js
@@ -10,6 +10,10 @@
       ? window.ZPWZ_CONFIG.apiBase
       : "";
 
+  const FOCUSABLE =
+    'a[href],button,input,select,textarea,[tabindex]:not([tabindex="-1"])';
+  let dialogSeq = 0;
+
   // Load CSS (your original CSS preserved exactly)
   const style = document.createElement("style");
   style.textContent = `
@@ -149,6 +153,9 @@
 
     // Create modal overlay (hidden initially)
     let overlay = null;
+    let opener = null;
+    let onKeyDown = null;
+    let onFocusIn = null;
 
     function open() {
       if (overlay) return;
@@ -227,6 +234,73 @@
       overlay.querySelector(".zwg-x").onclick = close;
       overlay.querySelector(".zwg-close").onclick = close;
 
+      // Dialog semantics + focus management (WAI-ARIA modal dialog pattern).
+      const modal = overlay.querySelector(".zwg-modal");
+      modal.setAttribute("role", "dialog");
+      modal.setAttribute("aria-modal", "true");
+      modal.tabIndex = -1;
+
+      const title = overlay.querySelector(".zwg-title");
+      if (title) {
+        title.id = `zwg-title-${++dialogSeq}`;
+        modal.setAttribute("aria-labelledby", title.id);
+      } else {
+        modal.setAttribute("aria-label", "Pay with Zcash");
+      }
+
+      const copyButtons = overlay.querySelectorAll(".zwg-copy");
+      if (copyButtons[0]) copyButtons[0].setAttribute("aria-label", "Copy address");
+      if (copyButtons[1]) copyButtons[1].setAttribute("aria-label", "Copy payment URI");
+      overlay.querySelectorAll("svg").forEach((s) => s.setAttribute("aria-hidden", "true"));
+
+      const active = document.activeElement;
+      opener =
+        active instanceof HTMLElement && active !== document.body ? active : btn;
+
+      const focusables = () =>
+        Array.from(overlay.querySelectorAll(FOCUSABLE)).filter(
+          (n) => !n.hasAttribute("disabled") && n.getAttribute("aria-hidden") !== "true",
+        );
+
+      onKeyDown = (e) => {
+        if (e.key === "Escape") {
+          e.preventDefault();
+          close();
+          return;
+        }
+        if (e.key !== "Tab") return;
+
+        const items = focusables();
+        if (items.length === 0) {
+          e.preventDefault();
+          modal.focus();
+          return;
+        }
+
+        const first = items[0];
+        const last = items[items.length - 1];
+        const current = document.activeElement;
+        const inside = overlay.contains(current);
+
+        if (e.shiftKey && (current === first || !inside || current === modal)) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && (current === last || !inside || current === modal)) {
+          e.preventDefault();
+          first.focus();
+        }
+      };
+
+      onFocusIn = (e) => {
+        if (overlay.contains(e.target)) return;
+        const items = focusables();
+        (items[0] || modal).focus();
+      };
+
+      document.addEventListener("keydown", onKeyDown);
+      document.addEventListener("focusin", onFocusIn);
+      modal.focus();
+
       overlay.querySelectorAll(".zwg-copy").forEach((b) => {
         b.onclick = async () => {
           try {
@@ -267,6 +341,8 @@
           `;
 
           overlay.querySelector(".zwg-acts").before(fld);
+          fld.querySelector(".zwg-copy").setAttribute("aria-label", "Copy short URL");
+          fld.querySelectorAll("svg").forEach((s) => s.setAttribute("aria-hidden", "true"));
 
           fld.querySelector(".zwg-copy").onclick = async function () {
             try {
@@ -289,8 +365,18 @@
 
     function close() {
       if (!overlay) return;
+      document.removeEventListener("keydown", onKeyDown);
+      document.removeEventListener("focusin", onFocusIn);
+      onKeyDown = null;
+      onFocusIn = null;
       overlay.remove();
       overlay = null;
+
+      const target = opener;
+      opener = null;
+      if (target && target.isConnected && typeof target.focus === "function") {
+        target.focus();
+      }
     }
 
     function destroy() {
@@ -298,6 +384,8 @@
       btn.remove();
     }
 
+    btn.setAttribute("aria-haspopup", "dialog");
+    btn.querySelectorAll("svg").forEach((s) => s.setAttribute("aria-hidden", "true"));
     btn.onclick = open;
 
     return { open, close, destroy };

--- a/src/app/[locale]/tools/zcash-payment-widget/PaymentRequestWidgetCodeSnippet.tsx
+++ b/src/app/[locale]/tools/zcash-payment-widget/PaymentRequestWidgetCodeSnippet.tsx
@@ -176,15 +176,71 @@ export default function PaymentRequestWidgetCodeSnippet({ config }: Props) {
   );
 }
 
-export function Modal({ isOpen, onClose, children }: any) {
-  const modalRef = useRef(null);
+const FOCUSABLE_SELECTOR =
+  'a[href],button:not([disabled]),input:not([disabled]),select:not([disabled]),textarea:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
-  // Close on Escape key
+export function Modal({ isOpen, onClose, label = "Dialog", children }: any) {
+  const modalRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  // Escape closes; Tab / Shift+Tab stay inside the panel.
   useEffect(() => {
-    const handleEsc = (e: any) => e.key === "Escape" && onClose();
-    if (isOpen) document.addEventListener("keydown", handleEsc);
-    return () => document.removeEventListener("keydown", handleEsc);
+    if (!isOpen) return;
+
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (e.key !== "Tab" || !panelRef.current) return;
+
+      const items = Array.from(
+        panelRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      );
+      if (items.length === 0) {
+        e.preventDefault();
+        panelRef.current.focus();
+        return;
+      }
+
+      const first = items[0];
+      const last = items[items.length - 1];
+      const current = document.activeElement;
+      const inside = panelRef.current.contains(current);
+
+      if (
+        e.shiftKey &&
+        (current === first || !inside || current === panelRef.current)
+      ) {
+        e.preventDefault();
+        last.focus();
+      } else if (
+        !e.shiftKey &&
+        (current === last || !inside || current === panelRef.current)
+      ) {
+        e.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
   }, [isOpen, onClose]);
+
+  // Move focus into the panel on open; restore it to the opener on close.
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const opener =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+    panelRef.current?.focus();
+
+    return () => {
+      if (opener && opener.isConnected) opener.focus();
+    };
+  }, [isOpen]);
 
   // Close on backdrop click
   const handleBackdropClick = (e: any) => {
@@ -202,6 +258,11 @@ export function Modal({ isOpen, onClose, children }: any) {
              p-5 animate-fade-in"
     >
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={label}
+        tabIndex={-1}
         className="w-full max-w-200 bg-white relative
              rounded-[28px] p-7 text-[--zwg-text]
              font-sans
@@ -209,6 +270,8 @@ export function Modal({ isOpen, onClose, children }: any) {
              animate-fade-out"
       >
         <button
+          type="button"
+          aria-label="Close"
           onClick={onClose}
           className="float-right text-gray-500 hover:text-gray-700 text-xl cursor-pointer"
         >

--- a/src/app/[locale]/tools/zcash-payment-widget/WidgetButtonTrigger.tsx
+++ b/src/app/[locale]/tools/zcash-payment-widget/WidgetButtonTrigger.tsx
@@ -44,6 +44,7 @@ function WidgetButtonTrigger({ config }: Props) {
           <div>
             <button
               disabled={config.disabled}
+              aria-haspopup="dialog"
               className={`
                 relative inline-flex items-center gap-2.5
                 px-7 py-3.5
@@ -60,7 +61,11 @@ function WidgetButtonTrigger({ config }: Props) {
               Preview Widget Snippet
             </button>
 
-            <Modal isOpen={open} onClose={() => setOpen(false)}>
+            <Modal
+              isOpen={open}
+              onClose={() => setOpen(false)}
+              label="Embed Code"
+            >
               <PaymentRequestWidgetCodeSnippet
                 config={{
                   ...config,

--- a/src/components/__tests__/paymentWidgetModal.test.tsx
+++ b/src/components/__tests__/paymentWidgetModal.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useState } from "react";
+import { Modal } from "@/app/[locale]/tools/zcash-payment-widget/PaymentRequestWidgetCodeSnippet";
+
+function Harness() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button aria-haspopup="dialog" onClick={() => setOpen(true)}>
+        Open
+      </button>
+      <Modal isOpen={open} onClose={() => setOpen(false)} label="Embed Code">
+        <button>First</button>
+        <input aria-label="Field" />
+        <button>Last</button>
+      </Modal>
+    </>
+  );
+}
+
+describe("payment widget code-snippet Modal", () => {
+  const user = userEvent.setup();
+
+  it("renders with dialog semantics and an accessible name", async () => {
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "Open" }));
+
+    const dialog = screen.getByRole("dialog", { name: "Embed Code" });
+    expect(dialog).toHaveAttribute("aria-modal", "true");
+    expect(dialog).toHaveAttribute("tabindex", "-1");
+    expect(screen.getByRole("button", { name: "Close" })).toHaveAttribute(
+      "type",
+      "button",
+    );
+  });
+
+  it("moves focus into the panel on open and restores it to the opener on close", async () => {
+    render(<Harness />);
+    const opener = screen.getByRole("button", { name: "Open" });
+    await user.click(opener);
+
+    expect(screen.getByRole("dialog")).toHaveFocus();
+
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
+  });
+
+  it("traps Tab and Shift+Tab inside the panel", async () => {
+    render(<Harness />);
+    await user.click(screen.getByRole("button", { name: "Open" }));
+
+    const close = screen.getByRole("button", { name: "Close" });
+    const last = screen.getByRole("button", { name: "Last" });
+
+    await user.tab();
+    expect(close).toHaveFocus();
+
+    last.focus();
+    await user.tab();
+    expect(close).toHaveFocus();
+
+    await user.tab({ shift: true });
+    expect(last).toHaveFocus();
+  });
+
+  it("closes via the × button and restores focus", async () => {
+    render(<Harness />);
+    const opener = screen.getByRole("button", { name: "Open" });
+    await user.click(opener);
+    await user.click(screen.getByRole("button", { name: "Close" }));
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
+  });
+
+  it("does not intercept keys once closed", async () => {
+    render(<Harness />);
+    const opener = screen.getByRole("button", { name: "Open" });
+    await user.click(opener);
+    await user.keyboard("{Escape}");
+
+    opener.focus();
+    await user.tab();
+    expect(opener).not.toHaveFocus();
+  });
+});

--- a/src/lib/__tests__/zcashPaymentWidgetEmbedA11y.test.ts
+++ b/src/lib/__tests__/zcashPaymentWidgetEmbedA11y.test.ts
@@ -1,0 +1,280 @@
+import fs from "fs";
+import path from "path";
+
+/**
+ * Accessibility regression tests for the embeddable payment widget's
+ * modal, run against the real public/zcash-payment-request-widget.embed.v2.js
+ * in jsdom. jsdom has no native sequential focus navigation, so Tab
+ * handling is verified by dispatching keydown events and asserting the
+ * widget's handler moved focus (which is exactly what it does in browsers).
+ */
+
+const EMBED_SCRIPT_PATH = path.join(
+  process.cwd(),
+  "public",
+  "zcash-payment-request-widget.embed.v2.js",
+);
+
+type WidgetInstance = {
+  open: () => void;
+  close: () => void;
+  destroy: () => void;
+};
+
+type RenderFn = (
+  selector: string,
+  opts: Record<string, unknown>,
+) => Promise<WidgetInstance | null | undefined>;
+
+async function render(opts: Record<string, unknown> = {}) {
+  document.body.innerHTML =
+    '<button id="before">before</button><div id="target"></div><button id="after">after</button>';
+  const fn = (window as unknown as { renderZcashButton: RenderFn })
+    .renderZcashButton;
+  const inst = await fn("#target", {
+    address: "t1VpMigELggqi6TBghQNehqspAcBBDYvRQC",
+    amount: 1,
+    zecUsdRate: 1,
+    label: "Coffee",
+    apiBase: "https://zechub.wiki/api",
+    ...opts,
+  });
+  if (!inst) throw new Error("widget did not render");
+  return inst;
+}
+
+const overlay = () => document.querySelector<HTMLElement>(".zwg-overlay");
+const modal = () => document.querySelector<HTMLElement>(".zwg-modal")!;
+const trigger = () => document.querySelector<HTMLButtonElement>(".zwg-btn")!;
+
+function key(name: string, opts: KeyboardEventInit = {}) {
+  const e = new KeyboardEvent("keydown", {
+    key: name,
+    bubbles: true,
+    cancelable: true,
+    ...opts,
+  });
+  (document.activeElement || document.body).dispatchEvent(e);
+  return e;
+}
+
+const focusablesInDialog = () =>
+  Array.from(
+    overlay()!.querySelectorAll<HTMLElement>(
+      'a[href],button,input,[tabindex]:not([tabindex="-1"])',
+    ),
+  );
+
+beforeAll(() => {
+  const source = fs.readFileSync(EMBED_SCRIPT_PATH, "utf8");
+  // eslint-disable-next-line no-new-func
+  new Function(source)();
+});
+
+beforeEach(() => {
+  (global as unknown as { fetch: unknown }).fetch = jest.fn();
+});
+
+describe("embed widget dialog accessibility", () => {
+  it("exposes dialog semantics with an accessible name from the title", async () => {
+    const inst = await render();
+    expect(trigger().getAttribute("aria-haspopup")).toBe("dialog");
+    expect(trigger().querySelector("svg")!.getAttribute("aria-hidden")).toBe("true");
+
+    inst.open();
+    const m = modal();
+    expect(m.getAttribute("role")).toBe("dialog");
+    expect(m.getAttribute("aria-modal")).toBe("true");
+    expect(m.tabIndex).toBe(-1);
+
+    const titleId = m.getAttribute("aria-labelledby");
+    expect(titleId).toBeTruthy();
+    expect(document.getElementById(titleId!)!.textContent).toBe("Coffee");
+    inst.close();
+  });
+
+  it("uses unique title ids across multiple widget instances", async () => {
+    const a = await render();
+    a.open();
+    const idA = modal().getAttribute("aria-labelledby");
+    a.close();
+
+    document.body.insertAdjacentHTML("beforeend", '<div id="target2"></div>');
+    const fn = (window as unknown as { renderZcashButton: RenderFn })
+      .renderZcashButton;
+    const b = (await fn("#target2", {
+      address: "t1VpMigELggqi6TBghQNehqspAcBBDYvRQC",
+      amount: 1,
+      zecUsdRate: 1,
+      label: "Tea",
+    }))!;
+    b.open();
+    expect(modal().getAttribute("aria-labelledby")).not.toBe(idA);
+    b.close();
+  });
+
+  it("labels the copy buttons and hides decorative icons", async () => {
+    const inst = await render();
+    inst.open();
+    const copies = overlay()!.querySelectorAll(".zwg-copy");
+    expect(copies[0].getAttribute("aria-label")).toBe("Copy address");
+    expect(copies[1].getAttribute("aria-label")).toBe("Copy payment URI");
+    overlay()!
+      .querySelectorAll("svg")
+      .forEach((s) => expect(s.getAttribute("aria-hidden")).toBe("true"));
+    inst.close();
+  });
+
+  it("labels the dynamically created short-URL copy button", async () => {
+    (global as unknown as { fetch: jest.Mock }).fetch.mockResolvedValue({
+      json: async () => ({ shortUrl: "https://zechub.wiki/s/abc" }),
+    });
+    const inst = await render();
+    inst.open();
+    overlay()!.querySelector<HTMLButtonElement>(".zwg-short")!.click();
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const copies = overlay()!.querySelectorAll(".zwg-copy");
+    expect(copies[copies.length - 1].getAttribute("aria-label")).toBe(
+      "Copy short URL",
+    );
+    inst.close();
+  });
+
+  it("moves focus into the dialog on open and restores it to the trigger on close", async () => {
+    const inst = await render();
+    trigger().focus();
+    trigger().click();
+
+    expect(overlay()).not.toBeNull();
+    expect(overlay()!.contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).toBe(modal());
+
+    key("Escape");
+    expect(overlay()).toBeNull();
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it("restores focus to whatever element opened it programmatically", async () => {
+    const inst = await render();
+    const before = document.getElementById("before")!;
+    before.focus();
+    inst.open();
+    expect(document.activeElement).toBe(modal());
+    inst.close();
+    expect(document.activeElement).toBe(before);
+  });
+
+  it("restores focus when closed via the × button and via backdrop click", async () => {
+    const inst = await render();
+    trigger().focus();
+    inst.open();
+    overlay()!.querySelector<HTMLButtonElement>(".zwg-x")!.click();
+    expect(overlay()).toBeNull();
+    expect(document.activeElement).toBe(trigger());
+
+    inst.open();
+    overlay()!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(overlay()).toBeNull();
+    expect(document.activeElement).toBe(trigger());
+  });
+
+  it("traps Tab and Shift+Tab inside the dialog", async () => {
+    const inst = await render();
+    inst.open();
+    const items = focusablesInDialog();
+    const first = items[0];
+    const last = items[items.length - 1];
+    expect(items.length).toBeGreaterThan(2);
+
+    // Forward Tab from the container goes to the first focusable.
+    let e = key("Tab");
+    expect(e.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(first);
+
+    // Tab from the last element wraps to the first.
+    last.focus();
+    e = key("Tab");
+    expect(e.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(first);
+
+    // Shift+Tab from the first element wraps to the last.
+    e = key("Tab", { shiftKey: true });
+    expect(e.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(last);
+
+    // Tab in the middle is left to the browser.
+    items[1].focus();
+    e = key("Tab");
+    expect(e.defaultPrevented).toBe(false);
+
+    inst.close();
+  });
+
+  it("pulls focus back when it lands outside the dialog", async () => {
+    const inst = await render();
+    inst.open();
+    const after = document.getElementById("after")!;
+    after.focus();
+    expect(overlay()!.contains(document.activeElement)).toBe(true);
+    inst.close();
+  });
+
+  it("keeps focus on the container when there are no focusable descendants", async () => {
+    const inst = await render();
+    inst.open();
+    focusablesInDialog().forEach((n) => n.setAttribute("disabled", ""));
+    modal().focus();
+    const e = key("Tab");
+    expect(e.defaultPrevented).toBe(true);
+    expect(document.activeElement).toBe(modal());
+    inst.close();
+  });
+
+  it("removes document listeners on close so the host page is not trapped", async () => {
+    const inst = await render();
+    inst.open();
+    inst.close();
+
+    const after = document.getElementById("after")!;
+    after.focus();
+    expect(document.activeElement).toBe(after);
+
+    const tab = key("Tab");
+    expect(tab.defaultPrevented).toBe(false);
+    expect(document.activeElement).toBe(after);
+    const esc = key("Escape");
+    expect(esc.defaultPrevented).toBe(false);
+  });
+
+  it("handles repeated open/close cycles and destroy while open", async () => {
+    const inst = await render();
+    for (let i = 0; i < 3; i++) {
+      trigger().focus();
+      inst.open();
+      expect(document.activeElement).toBe(modal());
+      key("Escape");
+      expect(overlay()).toBeNull();
+      expect(document.activeElement).toBe(trigger());
+    }
+
+    inst.open();
+    expect(() => inst.destroy()).not.toThrow();
+    expect(overlay()).toBeNull();
+    expect(document.querySelector(".zwg-btn")).toBeNull();
+
+    const after = document.getElementById("after")!;
+    after.focus();
+    expect(key("Tab").defaultPrevented).toBe(false);
+  });
+
+  it("still closes on backdrop click but not on clicks inside the panel", async () => {
+    const inst = await render();
+    inst.open();
+    modal().dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(overlay()).not.toBeNull();
+    overlay()!.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(overlay()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem
The payment-widget dialogs were missing key modal-dialog accessibility behavior, including dialog semantics, accessible naming, focus management, focus trapping, Escape handling, and focus restoration.

## Embed widget fixes
- `role="dialog"`
- `aria-modal="true"`
- accessible dialog name via `aria-labelledby` with fallback `aria-label`
- programmatic initial focus
- Tab / Shift+Tab focus trap
- Escape closes
- focus restored to opener
- outside focus pulled back into the dialog
- listener cleanup on close/destroy
- repeated open/close support
- accessible labels for copy buttons
- decorative SVGs `aria-hidden`
- `aria-haspopup="dialog"` on trigger
- zero-focusable fallback

## React Modal fixes
- dialog semantics and accessible name
- initial focus
- Tab / Shift+Tab trap
- Escape remains supported
- focus restoration
- accessible close button with `type="button"`
- `aria-haspopup="dialog"` on trigger

## Tests
- embed accessibility tests: 13/13 passed
- React modal tests: 5/5 passed
- full Jest suite: 16 suites / 148 tests passed
- ESLint clean
- no new TypeScript errors in changed files
- `node --check` passed
- `git diff --check` clean
- without the fix, 14/18 new accessibility tests fail, confirming the regression coverage is meaningful

## Scope / boundaries
- no PR #810 files touched
- no ZIP-321 logic changed
- branch is based directly on `main`
- PRs #815 and #817 touch nearby parts of the embed script; this PR intentionally uses post-build class hooks to reduce conflict risk and does not stack on either PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015sXn8ePeRtesmkUXhEdL7s